### PR TITLE
HACDOCS-460: Trying to fix broken internal xrefs.

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/Import-code/proc_importing_code.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/Import-code/proc_importing_code.adoc
@@ -135,10 +135,9 @@ When you import code, {ProductName} analyzes your repository to determine the ri
 
 * **Your repository contains a Dockerfile in an unexpected directory.**
 +
-If {ProductName} finds a Dockerfile in your repository, it determines that a Dockerfile runtime is the most suitable for building and deploying you application. However, if the Dockerfile is not saved in one of the following expected locations, an error in determining the right runtime for your components can occur:
+If {ProductName} finds a Dockerfile in your repository, it determines that a Dockerfile runtime is the most suitable for building and deploying you application. However, if the Dockerfile is not saved in one of the following expected locations, an error in determining the right runtime for your components can occur [[expected-dockerfile-locations, expected Dockerfile locations]]:
 +
-[#expected Dockerfile locations]
-.Expected Dockerfile locations
+.Expected Dockerfile locations 
 ** Dockerfile
 ** docker/Dockerfile
 ** .docker/Dockerfile/build/Dockerfile
@@ -155,9 +154,8 @@ If {ProductName} finds a Dockerfile in your repository, it determines that a Doc
 ====
 Test your Dockerfile in a local environment first to make sure it's valid.
 ====
-
-[#repository requirements]
-* **Your repository does not contain a Dockerfile or devfile.**
++
+* Your repository does not contain a Dockerfile or devfile. [[repository-requirements]]
 +
 If your code import fails because your repository is missing either a Dockerfile or devfile, check one of the following readme files for guidance, depending on the runtime you want to build and deploy with. These readme files provide details like required ports, file locations, commands, and more. 
 +
@@ -177,10 +175,9 @@ If your code import fails because your repository is missing either a Dockerfile
 +
 ** Make sure that your `devfile.yaml` points to the correct directories for both your Dockerfile and your Kubernetes YAML file. 
 ** Make sure that neither of these resources is in a private repository that requires access authentication.
-** Make sure that your devfile is in one of these expected locations:
+** Make sure that your devfile is in one of these expected locations [[expected-devfile-locations, expected devfile locations]]:
 +
-[#expected devfile locations] 
-.Expected devfile locations
+.Expected devfile locations 
 *** devfile.yaml
 *** .devfile.yaml
 *** .devfile/devfile.yaml
@@ -192,12 +189,11 @@ Some repositories require custom build or deployment instructions; for example, 
 +
 **Solutions**
 +
-[#custom build and deployment instructions]
-** **Configure a custom build.** Include a Dockerfile that can build your application, then save it to one of the <<expected Dockerfile locations>>. **Note:** If your build is custom but your deployment is not, you do not have to include a `devfile.yaml` file in your repository.
+** Configure a custom build. [[custom-build, custom build and deployment instructions]] Include a Dockerfile that can build your application, then save it to one of the <<expected-dockerfile-locations>>. **Note:** If your build is custom but your deployment is not, you do not have to include a `devfile.yaml` file in your repository.
 ** **Configure a custom deployment.** Include the following files in your repository to provide {ProductName} with custom deployment instructions:
 *** A standard Kubernetes YAML file
 *** A custom-build Dockerfile
-*** A devfile that points to your Kubernetes YAML file and Dockerfile. **Note:** Make sure that your devfile is in one of the <<expected devfile locations>>.
+*** A devfile that points to your Kubernetes YAML file and Dockerfile. **Note:** Make sure that your devfile is in one of the <<expected-devfile-locations>>.
 +
 [TIP]
 ====
@@ -212,9 +208,9 @@ For more information about devfile contents requirements, see the "What is outer
 
 * **{ProductName} couldn't detect the appropriate runtime.**
 +
-**Solution:** Select a predefined runtime type from the **Review and configure for deployment** view. Make sure you meet all of the {ProductName} <<repository requirements>> for the runtime you select, or configure your own <<custom build and deployment instructions>>.
+**Solution:** Select a predefined runtime type from the **Review and configure for deployment** view. Make sure you meet all of the {ProductName} <<repository-requirements>> for the runtime you select, or configure your own <<custom-build>>.
 
 [role="_additional-resources"]
 .Additional resources
-For information about importing and configuring code to {ProductName} using the CLI, see link:https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/getting-started/getting_started_in_cli/#getting-started-in-the-cli[Getting started in the CLI
+For information about importing and configuring code to {ProductName} using the CLI, see link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/getting-started/getting_started_in_cli/[Getting started with CLI
 ].


### PR DESCRIPTION
There are 4 broken internal xrefs in the upstream Importing and configuring code content [here](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/how-to-guides/Import-code/proc_importing_code/).