### PR TITLE
Rearranges How-to section

### DIFF
--- a/docs/modules/ROOT/nav-how-to-guides.adoc
+++ b/docs/modules/ROOT/nav-how-to-guides.adoc
@@ -1,15 +1,15 @@
 * xref:how-to-guides/how-to-guide-landing-page.adoc[How-to guides]
 ** xref:how-to-guides/Import-code/proc_importing_code.adoc[Importing and configuring code]
 ** xref:how-to-guides/proc_upgrade_build_pipeline.adoc[Upgrading the build pipeline]
-** Testing your application
-*** xref:how-to-guides/testing_applications/con_test-overview.adoc[Overview of {ProductName} Test components]
-*** xref:how-to-guides/testing_applications/surface-level_tests.adoc[Surface-level test]
 ** Securing your supply chain
 *** xref:how-to-guides/Secure-your-supply-chain/proc_inspect_sbom.adoc[Inspecting SBOMs]
 *** xref:how-to-guides/Secure-your-supply-chain/proc_inspect-slsa-provenance.adoc[Downloading your SLSA provenance]
 *** xref:how-to-guides/Secure-your-supply-chain/proc_java_dependencies.adoc[Configuring dependencies rebuild for Java apps in the CLI]
+** Testing your application
+*** xref:how-to-guides/testing_applications/con_test-overview.adoc[Overview of {ProductName} Test components]
+*** xref:how-to-guides/testing_applications/surface-level_tests.adoc[Surface-level tests]
+*** xref:how-to-guides/testing_applications/creating_a_custom_application_test_with_test_pipelines.adoc[Creating a custom application test]
 ** xref:how-to-guides/proc_creating_your_own_environment.adoc[Creating your own environment]
-** xref:how-to-guides/creating_a_custom_application_test_with_test_pipelines.adoc[Creating a custom application test with test pipelines]
 ** xref:how-to-guides/proc_managing-compliance-with-the-enterprise-contract.adoc[Managing compliance with the Enterprise Contract]
 ** xref:how-to-guides/proc_delete_application.adoc[Deleting an application].
 

--- a/docs/modules/ROOT/pages/how-to-guides/how-to-guide-landing-page.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/how-to-guide-landing-page.adoc
@@ -11,20 +11,20 @@ Provides procedures on downloading SBOMS through the UI and using the CLI.
 
 .xref:how-to-guides/Secure-your-supply-chain/proc_java_dependencies.adoc[**Configuring dependencies rebuild for Java applications**]
 
-Provides procedures on configuring dependencies rebuild for Java applications
+Provides procedures on configuring dependencies rebuild for Java applications.
 
 
 .xref:how-to-guides/proc_creating_your_own_environment.adoc[**Creating your own environment**]
 
 Provides procedures on creating your own environment.
 
-.xref:how-to-guides/creating_a_custom_application_test_with_test_pipelines.adoc[**Creating a Custom Application Test with Test Pipelines**]
+.xref:how-to-guides/testing_applications/creating_a_custom_application_test_with_test_pipelines.adoc[**Creating a Custom Application Test with Test Pipelines**]
 
-Provides procedures on how integration services use Tekton test pipelines and test scenarios.
+Provides procedures for creating your own Tekton test pipelines and test scenarios.
 
-.xref:how-to-guides/testing_applications/con_test-overview.adoc[**Testing applications**]
+.xref:how-to-guides/testing_applications/con_test-overview.adoc[**Overview of {ProductName} test components**]
 
-Provides information on {ProductName} test components and surface-level tests
+Provides information about {ProductName} test components and surface-level tests.
 
 .xref:how-to-guides/proc_managing-compliance-with-the-enterprise-contract.adoc[**Managing compliance with the Enterprise Contract**]
 

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/creating_a_custom_application_test_with_test_pipelines.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/creating_a_custom_application_test_with_test_pipelines.adoc
@@ -1,4 +1,4 @@
-= Creating a Custom Application Test with Test Pipelines
+= Creating a custom application test
 
 == How integration services use Tekton test pipelines and test scenarios
 


### PR DESCRIPTION
This PR renames one doc: it used to be "Creating a Custom Application Test with Test Pipelines", now it's just "Creating a custom application test". It moves that doc into the "Testing applications" section, where it should've been already. The PR also moves the "Secure your supply chain" section above the "Testing applications" section. And it edits the How-tos overview, since that doc was affected by these changes.