### PR TITLE
RHTAPBUGS-404 fixing broken stonesoup links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# Stonesoup documentation
+# App Studio documentation
 
-Stonesoup is an effort to automate build and delivery of Red Hat products. With Stonesoup, you have access to single, simple workflow for developing, testing, and releasing containerized applications while ensuring compliance with enterprise security standards.
+App Studio is an effort to automate build and delivery of Red Hat products. With App Studio, you have access to single, simple workflow for developing, testing, and releasing containerized applications while ensuring compliance with enterprise security standards.
 
-## Stonesoup documentation links
+## App Studio documentation links
 
-* [Getting-Started Guide](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/users/getting_started.html)
-* [User Documentation](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/users/index.html/120v38DZY6iuHlnyJJ2_k78vwhNiA38LqIZIzTT9j8aM)
-* [Developer Documentation](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/developers/index.html)
-* [Schema Documentation](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/schema/index.html)
-* [Architecture Overview](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/architecture/index.html)
+* [Getting started guide](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/getting-started/get-started)
+* [User documentation](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main)
+* [Upstream landing page](https://redhat-appstudio.github.io/appstudio.docs.ui.io/)
+<!-- * [Schema Documentation](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/schema/index.html) -->
+<!-- * [Architecture Overview](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/architecture/index.html) -->
 
-## External Links
+## External links
 
-* [Stonesoup Console (Confluence)](https://docs.engineering.redhat.com/pages/viewpage.action?pageId=256849149)
-* [Stonesoup Project Status Dashboard](https://docs.google.com/document/d/1wzJu-wOYez5p875kl0QkgQ6b2i9x_T9983YdxTxBd-I/edit?usp=sharing)
+* [HACDOCS project in JIRA](https://issues.redhat.com/projects/HACDOCS/summary)
+* [HACBS hub on Confluence](https://docs.engineering.redhat.com/pages/viewpage.action?pageId=256849149)
 
-## Stonesoup Contact Information
+## App Studio contact information
 
-* [Stonesoup Documentation Home Page](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/)
-* [Stonesoup Documentation GitLab Repository](https://gitlab.cee.redhat.com/red-hat-hybrid-application-cloud-build-services-documentation/Stonesoup-documentation)
-* [Email: Stonesoup Development Team](mailto:Stonesoup@googlegroups.com)
-* [Google chat: Stonesoup Users](https://groups.google.com/g/Stonesoup)
+* [App Studio documentation home page](https://redhat-appstudio.github.io/appstudio.docs.ui.io/)
+* [App Studio documentation GitLab repository](https://gitlab.cee.redhat.com/red-hat-trusted-application-pipeline/red-hat-trusted-application-pipeline)
+<!-- * [Email: Stonesoup Development Team](mailto:Stonesoup@googlegroups.com) -->
+<!-- * [Google chat: Stonesoup Users](https://groups.google.com/g/Stonesoup) -->
 
 ## Notes
 
@@ -32,9 +32,9 @@ File Guide (The Source):
 
 ## References for documentation team
 
-* We used AsciiDoc to document Stonesoup (https://docs.asciidoctor.org/asciidoc/latest/#about-asciidoc).
+* We used AsciiDoc to document App Studio (https://docs.asciidoctor.org/asciidoc/latest/#about-asciidoc).
 * We created this website using Antora (https://docs.antora.org/antora/latest/). We use Antora because it provides a search capability that we can customize.
-* We manage documentation in GitLab. They are in a repository (<https://gitlab.cee.redhat.com/red-hat-hybrid-application-cloud-build-services-documentation/Stonesoup-documentation>). We use GitLab to manage publication - continuous integration settings in the repository automatically generate the web site when changes are merged and GitLab Pages is used to publish the website here <https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/>.
+* We manage documentation in GitLab. They are in a repository (<https://gitlab.cee.redhat.com/red-hat-trusted-application-pipeline/red-hat-trusted-application-pipeline>). We use GitLab to manage publication - continuous integration settings in the repository automatically generate the web site when changes are merged and GitLab Pages is used to publish the website here <https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/>.
 
 ### Required tools
 
@@ -230,4 +230,4 @@ For convenience there is also the `dev` script, that can be run with `npm run de
 
 * On your system: After setup (to set up follow reference information) run the following command on your terminal: `npx antora --fetch antora-playbook.yml`
 
-* Merge you changes and refresh the Stonesoup documentation link, which is, <https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/>
+* Merge you changes and refresh the App Studio documentation link, which is, <https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main>

--- a/README.md
+++ b/README.md
@@ -7,18 +7,13 @@ App Studio is an effort to automate build and delivery of Red Hat products. With
 * [Getting started guide](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/getting-started/get-started)
 * [User documentation](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main)
 * [Upstream landing page](https://redhat-appstudio.github.io/appstudio.docs.ui.io/)
-<!-- * [Schema Documentation](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/schema/index.html) -->
-<!-- * [Architecture Overview](https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/architecture/index.html) -->
 
 ## External links
 
 * [HACDOCS project in JIRA](https://issues.redhat.com/projects/HACDOCS/summary)
 * [HACBS hub on Confluence](https://docs.engineering.redhat.com/pages/viewpage.action?pageId=256849149)
 
-## App Studio contact information
-
-* [App Studio documentation home page](https://redhat-appstudio.github.io/appstudio.docs.ui.io/)
-* [App Studio documentation GitLab repository](https://gitlab.cee.redhat.com/red-hat-trusted-application-pipeline/red-hat-trusted-application-pipeline)
+<!-- ## App Studio contact information -->
 <!-- * [Email: Stonesoup Development Team](mailto:Stonesoup@googlegroups.com) -->
 <!-- * [Google chat: Stonesoup Users](https://groups.google.com/g/Stonesoup) -->
 
@@ -34,7 +29,6 @@ File Guide (The Source):
 
 * We used AsciiDoc to document App Studio (https://docs.asciidoctor.org/asciidoc/latest/#about-asciidoc).
 * We created this website using Antora (https://docs.antora.org/antora/latest/). We use Antora because it provides a search capability that we can customize.
-* We manage documentation in GitLab. They are in a repository (<https://gitlab.cee.redhat.com/red-hat-trusted-application-pipeline/red-hat-trusted-application-pipeline>). We use GitLab to manage publication - continuous integration settings in the repository automatically generate the web site when changes are merged and GitLab Pages is used to publish the website here <https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/>.
 
 ### Required tools
 
@@ -68,13 +62,13 @@ For convenience there is also the `dev` script, that can be run with `npm run de
 
 - **New:** on your queue but you haven’t started yet.
 
-- **Refinement:** research it, read up on it, talk to SMEs about it. In a Jira comment, you can recap your research and SME conversations. You understand it enough to make a GDoc or Merge Request (MR).
+- **Refinement:** research it, read up on it, talk to SMEs about it. In a Jira comment, you can recap your research and SME conversations. You understand it enough to make a GDoc or Pull Request (PR).
 - For bigger doc tasks, like creating entirely new documents, writing abstracts, developing procedures, etc., you might find it best to start  in a GDoc.
-- In the GDoc, you can receive reviews quickly and address reviews quickly. Once the doc is in good shape, you can take the content from the GDoc, and put in an ascii doc file and make a MR. This way, the MR is opened and closed quicker.
+- In the GDoc, you can receive reviews quickly and address reviews quickly. Once the doc is in good shape, you can take the content from the GDoc, and put in an ascii doc file and make a PR. This way, the PR is opened and closed quicker.
 -  **In Progress:** you’re now writing or making a file update. You have something to share beyond a Jira comment or status update.
-- **Review:** you’ve elicited a peer review from docs, devs, and QE. You address the review as it comes. During the review stage, your content can be in either a GDoc or MR.
+- **Review:** you’ve elicited a peer review from docs, devs, and QE. You address the review as it comes. During the review stage, your content can be in either a GDoc or PR.
 - Depending on the task, you might not need a review from all three: dev, doc, QE. For instance, fixing a broken link might only require a QE review. Changing a grammatical error might only require a doc review. Use your best judgment.
-- **Closed:** reviews are complete and addressed. The MR is merged and the content is published.
+- **Closed:** reviews are complete and addressed. The PR is merged and the content is published.
 
 ## Docs workflow with Dev and QE
 
@@ -90,21 +84,21 @@ For convenience there is also the `dev` script, that can be run with `npm run de
 
 3. Review.
 
-- If in a GDoc, add comments and update the GDoc until the content is ready to be converted into an ascii doc and shared in a MR.
-- When the MR is created, the engineers review it and provide:
+- If in a GDoc, add comments and update the GDoc until the content is ready to be converted into an ascii doc and shared in a PR.
+- When the PR is created, the engineers review it and provide:
 - Technical accuracy of content, not grammatical and language review.
 - Provide user perspective.
-- Writer responds to the review. Updates the Gdoc or MR and repeats until the review is complete and the doc is ready be published.
+- Writer responds to the review. Updates the Gdoc or PR and repeats until the review is complete and the doc is ready be published.
 
 ## Git workflow
 
-### Forking and cloning Git Lab repository
+### Forking and cloning GitHub repository
 
-1. Fork the git lab repository from the git lab user interface  (UI).
+1. Fork the GitHub repository from the GitHub user interface  (UI).
 2. On the command line interface (CLI) on your local machine, run the following commands:
-3. `git clone git@gitlab.com<your-gitlab-username>/<gitlab repository you’re cloning>`
-4. `cd <gitlab repository>`
-5. `git remote add -f upstream <git@gitlab.com>/<gitlab repository>`
+3. `git clone git@github.com:<your-github-username>/<github repository you’re cloning>.git`
+4. `cd <github repository>`
+5. `git remote add -f upstream <git@github.com>/<github repository>`
 6. `git checkout main`
 7. `git remote -v`
 
@@ -113,10 +107,10 @@ For convenience there is also the `dev` script, that can be run with `npm run de
 8. Now you’re ready to start contributing!
 
 
-### Making a merge request (MR)
+### Making a pull request (PR)
 
 1. `cd <name of place where you stored the cloned repo/<name of repo>`
-    Ex: cd documents/Stonesoup-documentation/
+    Ex: cd documents/docs.appstudio.io/
 2. `git checkout main`
 3. `git fetch upstream`
     Git data from upstream repo (the main repo)
@@ -169,17 +163,17 @@ For convenience there is also the `dev` script, that can be run with `npm run de
 
 13. `git push -u origin <feature branch>`
 
-- This command creates the MR, and the MR is asking to merge your feature branch into the main repository.
+- This command creates the PR, and the PR is asking to merge your feature branch into the main repository.
 
 - You don’t need `git push -upstream origin <feature branch>` remember, origin is the default. Like in step 
 5, it’s superfluous. You’re already on feature branch and staged the commit, so simply push it!
 
-14. Go to GL to make the MR
+14. Go to GitHub to make the PR
 
-15. Tag people, write messages, do what you must to receive peer reviews of your newly created MR.
+15. Tag people, write messages, do what you must to receive peer reviews of your newly created PR.
 
 
-### Making commits for a MR
+### Making commits for a PR
 
 1. `cd <location of repo>/<name of repo>`
 2. `git checkout main`
@@ -212,17 +206,15 @@ For convenience there is also the `dev` script, that can be run with `npm run de
 
 13. `git commit --amend`
 
-- This will add any updates to your previous commit within the MR. If you do want to create a 2nd commit in the MR, run the command: `git commit -m <name of commit message>`
+- This will add any updates to your previous commit within the PR. If you do want to create a 2nd commit in the PR, run the command: `git commit -m <name of commit message>`
 
 14. `git push`
 
-- After you make a MR, you ought to be able to simply run `git push` to make a new commit. If you get any error messages, try `git push -u origin <feature branch>`
+- After you make a PR, you ought to be able to simply run `git push` to make a new commit. If you get any error messages, try `git push -u origin <feature branch>`
 
-15. Go to MR to ensure the commit has been made.
+15. Go to PR to ensure the commit has been made.
 
 - Tag reviewers, direct their attention to specific areas of content or whatever you see fit.
-
-
 
 
 

--- a/docs/modules/ROOT/pages/how-to-guides/proc_release_application.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/proc_release_application.adoc
@@ -25,7 +25,7 @@ To release an application to a managed environment:
 
 . The development team creates a xref:how-to-guides/proc_release_application.adoc#_creating_a_releaseplan_object[`ReleasePlan`] object in the developer workspace. The `ReleasePlan` object includes a reference to the application that the development team wants to release, along with the namespace and workspace where the application is suppose to release.
 
-. The Managed environment team creates a xref:how-to-guides/proc_release_application.adoc#_creating_a_releasestrategy_object[`ReleaseStrategy`] object to ensure that the release of an application meets link:https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/ec-policies/index.html[enterprise contract].
+. The Managed environment team creates a xref:how-to-guides/proc_release_application.adoc#_creating_a_releasestrategy_object[`ReleaseStrategy`] object to ensure that the release of an application meets link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/proc_managing-compliance-with-the-enterprise-contract[enterprise contract].
 
 . The Managed environment team creates a xref:how-to-guides/proc_release_application.adoc#_creating_a_releaseplanadmission_object[`ReleasePlanAdmission`] object in the managed workspace.
 

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/con_test-overview.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/con_test-overview.adoc
@@ -18,7 +18,7 @@ By default, {ProductName} performs Surface-level and Product Security tests. You
 
 ==== Surface-level tests
 
-Surface-level tests in {ProductName} ensure the stability of the application, the build pipeline, its components, and the environment in which it is being tested. The surface-level tests used in {ProductName} are executed in the form of link:https://tekton.dev/docs/pipelines/tasks/#overview[Tekton tasks]. The utility used for validating container information is link:https://www.conftest.dev/[conftest]. A full listing of {ProductName} Surface-level tests can be link:https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/concepts/testing_applications/surface-level_tests.html[found here].
+Surface-level tests in {ProductName} ensure the stability of the application, the build pipeline, its components, and the environment in which it is being tested. The surface-level tests used in {ProductName} are executed in the form of link:https://tekton.dev/docs/pipelines/tasks/#overview[Tekton tasks]. The utility used for validating container information is link:https://www.conftest.dev/[conftest]. A full listing of {ProductName} Surface-level tests can be link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/testing_applications/surface-level_tests[found here].
 
 ==== Product Security tests
 

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/con_test-overview.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/con_test-overview.adoc
@@ -28,15 +28,21 @@ Product Security tests in {ProductName} ensure a product is secure and keep your
 * Anti Virus Scanning via ClamAV
 * Code scanning via SAST tools
 
-These tests can be made mandatory as part of the link:https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/concepts/enterprise-contract/con_enterprise-contract-overview.html[Enterprise Contract]
+These tests can be made mandatory as part of the link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/proc_managing-compliance-with-the-enterprise-contract[Enterprise Contract]
+// The link used to point to concepts/release-services/con_release-services-overview which is no longer available. A new link probably doesn't make sense because the linked doc doesn't mention prodsec tests listed above.
 
 ==== Custom tests
 
-Custom tests in {ProductName} are tests that are created and implemented by users and administrators. You can add tests to your environment as needed. Custom tests are written as tekton tasks and implemented into your pipeline. For full instructions on creating and importing tests, please see our guide https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/concepts/testing_applications/adding_new_tests.html[Add a New Test].
+Custom tests in {ProductName} are tests that are created and implemented by users and administrators. You can add tests to your environment as needed. Custom tests are written as tekton tasks and implemented into your pipeline.
+// NEW LINK REQUIRED For full instructions on creating and importing tests, please see our guide https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/concepts/testing_applications/adding_new_tests.html[Add a New Test].
 
 === Integration service tests
 
-Integration tests occur after each component included in the build has passed testing. Integration testing ensures that all build components are able to work together at the same time. Images of all the application components are compiled into a Snapshot of the application. The Snapshot is then tested against user defined IntegrationTestScenarios, which refer to a link:https://tekton.dev/docs/pipelines/tekton-bundle-contracts/[Tekton bundle]. All images created are stored in a Quay.io repository. If all integration tests pass, a Release resource is created for each ReleasePlan. The Release resource will notify the https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/concepts/release-services/con_release-services-overview.html[Release service] that the application is ready to be promoted to the next environment.
+Integration tests occur after each component included in the build has passed testing. Integration testing ensures that all build components are able to work together at the same time. Images of all the application components are compiled into a Snapshot of the application. The Snapshot is then tested against user defined IntegrationTestScenarios, which refer to a link:https://tekton.dev/docs/pipelines/tekton-bundle-contracts/[Tekton bundle]. All images created are stored in a Quay.io repository. If all integration tests pass, a Release resource is created for each ReleasePlan. The Release resource will notify the Release service that the application is ready to be promoted to the next environment.
+// NEW LINK REQUIRED: The old link is commented out in nav-concepts.adoc https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/concepts/release-services/con_release-services-overview.html[Release service]
+
+////
+NEW LINKS REQUIRED: The old links are commented out in nav-concepts.adoc
 
 == Additional resources
 
@@ -45,3 +51,4 @@ To learn about other {ProductName} components that help you with your containeri
 * https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/concepts/release-services/con_release-services-overview.html[Release Service]
 * https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/concepts/enterprise-contract/con_enterprise-contract-overview.html[Enterprise Contract]
 * https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/concepts/pipelines/index.html[Pipeline Services]
+////

--- a/internal-resources/git-workflow-and-contributor-guide.adoc
+++ b/internal-resources/git-workflow-and-contributor-guide.adoc
@@ -76,9 +76,9 @@ IMPORTANT: If you are prompted for a password when you try to access GitHub, you
 
 Procedure
 
-Complete the following steps to fork the `docs.stonesoup.io` upstream repository and create a copy under your own GitHub ID: 
+Complete the following steps to fork the `docs.appstudio.io` upstream repository and create a copy under your own GitHub ID: 
 
-. Go to https://github.com/redhat-appstudio/docs.stonesoup.io. 
+. Go to https://github.com/redhat-appstudio/docs.appstudio.io. 
 . In the upper right corner, select *Fork*. 
 . In *Owner*, select your username. 
 . Enter a name and description.
@@ -100,22 +100,22 @@ Procedure
 
 Procedure
 
-After you have your fork checked out and cloned locally, add the `git@github.com:redhat-appstudio/docs.stonesoup.io.git` repository as a remote:
+After you have your fork checked out and cloned locally, add the `git@github.com:redhat-appstudio/docs.appstudio.io.git` repository as a remote:
 
 . List the current remote repositories:
 +
 [source,bash]
 ----
 $ git remote -v
-origin git@github.com:<username>/docs.stonesoup.io.git (fetch)
-origin git@github.com:<username>/docs.stonesoup.io.git (push)
+origin git@github.com:<username>/docs.appstudio.io.git (fetch)
+origin git@github.com:<username>/docs.appstudio.io.git (push)
 ----
 
 . Add the upstream as a remote repository and fetch its contents. This enables you to check out and work with the latest source code:
 +
 [source,bash]
 ----
-$ git remote add -f upstream  git@github.com:redhat-appstudio/docs.stonesoup.io.git
+$ git remote add -f upstream  git@github.com:redhat-appstudio/docs.appstudio.io.git
 ----
 
 . Verify that the new remote was added:
@@ -123,16 +123,16 @@ $ git remote add -f upstream  git@github.com:redhat-appstudio/docs.stonesoup.io.
 [source,bash]
 ----
 $ git remote -v
-origin git@github.com:<username>/docs.stonesoup.io.git (fetch)
-origin git@github.com:<username>/docs.stonesoup.io.git (push)
-upstream git@github.com:redhat-appstudio/docs.stonesoup.io.git (fetch)
-upstream git@github.com:redhat-appstudio/docs.stonesoup.io.git (push)
+origin git@github.com:<username>/docs.appstudio.io.git (fetch)
+origin git@github.com:<username>/docs.appstudio.io.git (push)
+upstream git@github.com:redhat-appstudio/docs.appstudio.io.git (fetch)
+upstream git@github.com:redhat-appstudio/docs.appstudio.io.git (push)
 ----
 . If the upstream repository is moved, you can change the upstream URL with the following command:
 +
 [source,bash]
 ----
-$ git remote set-url upstream git@github.com:redhat-appstudio/docs.stonesoup.io.git
+$ git remote set-url upstream git@github.com:redhat-appstudio/docs.appstudio.io.git
 ----
 
 Use the following commands any time that you need to fetch the latest source code locally:
@@ -151,7 +151,7 @@ Procedure
 Complete the following steps in your command line interface (CLI) before you make edits to the documentation: 
 
 . Run `cd [file location of your repo]`
-** For example, `cd ~/Documents/docs.stonesoup.io` 
+** For example, `cd ~/Documents/docs.appstudio.io` 
 . Run `git checkout main` to switch to the main branch.
 ** If you are already on the main branch, proceed to the following step.
 . Run `git fetch upstream` to download the data from the upstream, or main, repo.
@@ -182,7 +182,7 @@ Complete the following steps to make a change to the documentation in VS Code:
 . Open VS Code. 
 . Select *File > Open Folder*. 
 ** If you already have the proper folder open, proceed to step 4.
-. Navigate to *docs.stonesoup.io > docs > modules > ROOT > pages* and then select *Open*. 
+. Navigate to *docs.appstudio.io > docs > modules > ROOT > pages* and then select *Open*. 
 ** If you are editing different content in our repo, select the relevant folder. 
 . Open the file that you want to edit, or create a new file. 
 . Make changes to the document and reference the Ascii Doctor documentation if needed.
@@ -212,7 +212,7 @@ In the previous section, you created a pull request (PR). Next, we will find the
 
 Procedure
 
-. Navigate to https://github.com/redhat-appstudio/docs.stonesoup.io.
+. Navigate to https://github.com/redhat-appstudio/docs.appstudio.io.
 . Find your PR at the top of the window. 
 . Select *Compare & pull request*.
 . Enter a short description of your PR in *Description*. 
@@ -229,7 +229,7 @@ Procedure
 Complete the following steps only if you need to amend a PR:
 
 . Run `cd [file location of your repo]`.
-** For example, `cd ~/Documents/docs.stonesoup.io` 
+** For example, `cd ~/Documents/docs.appstudio.io` 
 . Run `git checkout main` to switch to the main branch.
 ** If you are already on the main branch, proceed to the following step.
 . Run `git fetch upstream` to download the data from the upstream, or main, repo.
@@ -365,7 +365,7 @@ NOTE: When building the local output, ensure to check the Build Warnings and Err
 +
 [source,bash]
 ----
-$ git commit -m "stonesoup-####: commit message"
+$ git commit -m "HACDOCS-####: commit message"
 ----
 [IMPORTANT]
  If there is a JIRA associated with this fix, be sure to prefix the commit message with the JIRA number. This makes it easy to trace back why a change was made to the topic.

--- a/internal-resources/git-workflow-and-contributor-guide.adoc
+++ b/internal-resources/git-workflow-and-contributor-guide.adoc
@@ -270,7 +270,7 @@ The following sections go into advanced resources that you might not need to use
 
 Now that you set up your tools, you are ready to edit the documentation. 
 
-You may want to need to do some more xref:advanced_git_operations[advanced Git operations], such as delete branches, access unmerged commits, or sync up your GitLab repository main branch with the official upstream repository. There is also a list of xref:useful_git_commands[useful Git commands]. Feel free to add to this list.
+You may want to need to do some more xref:advanced_git_operations[advanced Git operations], such as delete branches, access unmerged commits, or sync up your GitHub repository main branch with the official upstream repository. There is also a list of xref:useful_git_commands[useful Git commands]. Feel free to add to this list.
 
 [[check_out_a_topic_branch_from_the_upstream_repository]]
 == Check Out a Topic Branch from the Upstream Repository
@@ -383,7 +383,7 @@ You should see this result:
 ----
 nothing to commit, working directory clean
 ----
-. Use Git `log` to verify you only have the one commit in the log. If you have made multiple commits for this issue, be sure to xref:squash_multiple_commits_into_one[squash your commits into one] before you push your changes or issue your merge request.
+. Use Git `log` to verify you only have the one commit in the log. If you have made multiple commits for this issue, be sure to xref:squash_multiple_commits_into_one[squash your commits into one] before you push your changes or issue your pull request.
 +
 [source,bash]
 ----
@@ -399,16 +399,16 @@ $ git push origin HEAD
 [NOTE]
 This is the equivalent the command `git push origin TOPIC_BRANCH_NAME`. HEAD points to the top of the current branch so you do not need to remember or type the topic branch name.
 
-[[verify_your_changes_and_open_a_merge_request_to_upstream]]
-=== Verify Your Changes and Open a Merge Request to Upstream
+[[verify_your_changes_and_open_a_pull_request_to_upstream]]
+=== Verify Your Changes and Open a Pull Request to Upstream
 
 After you push your changes to your forked repository (origin), you should verify the changes are correct and then request they be merged back into the appropriate branch or branches in the upstream repository.
 
-Using the GitLab Web interface:
+Using the GitHub Web interface:
 
-. Navigate to your forked repository, for example, https://gitlab.cee.redhat.com/<username>/stonesoup-documentation.
-. Select the *Merge Requests* tab near the top of the page.
-. Select the *New Merge Request* button on the right side.
+. Navigate to your forked repository, for example, https://github.com/<username>/docs.appstudio.io
+. Select the *Pull Requests* tab near the top of the page.
+. Select the *New Pull Request* button on the right side.
 . Select the source branch, which is the new branch you just pushed to origin, for example, _myBugFix_.
 . Determine and select the destination branch or branches.
 * If the fix should be applied to the both the current {BranchCurrentRelease} release and previous {BranchPreviousRelease} release, you should choose to merge to  `upstream/{BranchCurrentmain}`.
@@ -437,17 +437,17 @@ Using the GitLab Web interface:
 . Select *Compare Branches*
 .. Select the *Commits* tab and verify that there is only one commit and it is the one you made.
 .. Select the *Changes* tab to view the files and changes that were committed. Make sure only the changes you expect are in the commit. If you see a modified file in the commit that does NOT belong, see xref:remove_a_file_from_a_commit[Remove a File From a Commit] for instructions to remove it.
-.. Fill in the details about your merge request, assign it to an administrator or peer reviewer, and select _Submit new merge request_.
+.. Fill in the details about your pull request, assign it to an administrator or peer reviewer, and select _Submit new pull request_.
 .. Add the label or labels or the targeted release as described in the above table.
-.. If this request targets both releases, add a comment in the merge request to alert the administrator.
+.. If this request targets both releases, add a comment in the pull request to alert the administrator.
 
-For more details on creating a merge request, see the http://doc.gitlab.com/ce/gitlab-basics/add-merge-request.html[GitLab documentation].
+For more details on creating a pull request, see the https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request[GitHub documentation].
 
 [[copy_the_doc_to_a_shared_server]]
 
-=== Modify a Merge Request
+=== Modify a Pull Request
 
-The administrator or others may make comments and request that you make fixes to your merge request before it is merged. Use the following procedure to make your updates for an existing merge request.
+The administrator or others may make comments and request that you make fixes to your pull request before it is merged. Use the following procedure to make your updates for an existing pull request.
 
 . If you have already started making changes in a new branch, you must _stash_ or _commit_ your changes before you continue.
 +
@@ -472,7 +472,7 @@ Later, when you are done with the merged branch and want to return to other  bra
 $ git checkout NEW_BRANCH_NAME
 $ git stash pop
 ----
-. Check out the branch that contains your changes and from which your issued the merge request.
+. Check out the branch that contains your changes and from which your issued the pull request.
 +
 [source,bash]
 ----
@@ -490,21 +490,21 @@ $ git push <-f> origin HEAD
 [NOTE]
 If you squash commits, you must use the `-f` flag to force the push to your repository.
 
-. The merge request should now reflect your latest updates. You do NOT need to issue another merge request when you use the same branch.
+. The pull request should now reflect your latest updates. You do NOT need to issue another pull request when you use the same branch.
 
 [[merge_request_workflow]]
-=== Merge Request Workflow
+=== Pull Request Workflow
 
-This section describes the workflow you should follow when you submit a merge request to the upstream main branch.
+This section describes the workflow you should follow when you submit a pull request to the upstream main branch.
 
-. Upon submitting a merge request:
+. Upon submitting a pull request:
 * Add the *Needs Peer Review* label and tag someone on the team to review the content.
 * Add a label for the target release for the fix, for example, *1.x.x*. If the fix must be applied to multiple branches, add a label for each and make sure there is a corresponding JIRA for each release where it needs to be applied.
 . If we are in a stage freeze prior to a portal push, you must also do the following.
 * If the fix is for a JIRA reopened by QE for this stage push, add the *Prod Push* label.
 * If the fix is not for a JIRA reopened from the stage push, prepend the JIRA title with "WIP:" or "[WIP]" and add the *WIP* label.
 
-. If the updates are a result of a JIRA, open the JIRA, select *Link Pull Request*, and paste the link to the GitLab merge request in the text box provided.
+. If the updates are a result of a JIRA, open the JIRA, select *Link Pull Request*, and paste the link to the GitHub pull request in the text box provided.
 . The reviewer should review the content and do one of the following.
 * If the content looks good, remove the *Needs Peer Review* label, add the *Ready to Merge* label, and comment that the code has been reviewed and looks good to merge.
 * If changes are required, leave the *Needs Peer Review* label in place, add the *Feedback Provided* label, and provide good comments about what needs to be changed.
@@ -515,8 +515,8 @@ This section describes the workflow you should follow when you submit a merge re
 The writer requesting the merge should _NOT_ add the *Ready to Merge* label at this point. The updated content still needs review and it is up to the reviewer to decide when it is ready.
 ====
 +
-This process continues until the reviewer marks the merge request *Ready to Merge*.
-. When a merge request is in a *Ready to Merge* state, a GitLab administrator does final review.
+This process continues until the reviewer marks the pull request *Ready to Merge*.
+. When a pull request is in a *Ready to Merge* state, a GitHub administrator does final review.
 * If the content looks good, the administrator can merge the request.
 * If the administrator finds a problem, the *Feedback Provided* label is added and comments are provided about what needs to be changed.
 . After the request is merged to main, open the related JIRA, select *Pull Request Closed* or *Workflow* -> *Resolve Issue*, add a comment and the link where the modified content can be previewed on the QA preview server (https://access.qa.redhat.com/documentation).
@@ -631,14 +631,14 @@ If you pushed this branch to origin before you rebased, you must use the `-f` ar
 $ git push -f origin HEAD
 ----
 +
-Alternatively, you can push it to a branch with a different name, and then close the original merge request and issue a new request for the new branch name.
+Alternatively, you can push it to a branch with a different name, and then close the original pull request and issue a new request for the new branch name.
 +
 [source,options="nowrap"]
 ----
 $ git push origin HEAD:branch-name-rebased
 ----
 
-. Using the GitLab Web interface, navigate to your forked repository, select *Create Merge Request* for this update, verify the changes look correct, and submit the new merge request.
+. Using the GitHub Web interface, navigate to your forked repository, select *Create Pull Request* for this update, verify the changes look correct, and submit the new pull request.
 
 [[fix_rebase_merge_conflicts]]
 === Fix Rebase Merge Conflicts
@@ -743,7 +743,7 @@ $ git rebase --abort
 [[add_new_changes_to_an_existing_commit]]
 === Add New Changes to an Existing Open Commit
 
-If you need to update the content for an existing, open merge request based on the peer, SME, or Git administrator review process, you can make the changes, stage them, and tack them onto the existing commit using the `--amend` option. This is a convenient way to rewrite history and merge the staged updates into the existing commit. This allows you to avoid the process defined under xref:squash_multiple_commits_into_one[Squash Multiple Commits into One].
+If you need to update the content for an existing, open pull request based on the peer, SME, or Git administrator review process, you can make the changes, stage them, and tack them onto the existing commit using the `--amend` option. This is a convenient way to rewrite history and merge the staged updates into the existing commit. This allows you to avoid the process defined under xref:squash_multiple_commits_into_one[Squash Multiple Commits into One].
 
 First, define a global alias for the `--amend` command so that Git does not prompt you with the `vi` editor and ask you to edit the commit message. This is a one-time task.
 
@@ -956,7 +956,7 @@ $ git push <-f> origin HEAD
 [[remove_a_file_from_a_commit]]
 === Remove a File From a Commit
 
-When you review your merge request, you may find you have mistakenly added a file to the commit that should not be there. You can remove it using the following commands.
+When you review your pull request, you may find you have mistakenly added a file to the commit that should not be there. You can remove it using the following commands.
 
 [source,options="nowrap"]
 ----
@@ -984,11 +984,11 @@ For more information, see: http://stackoverflow.com/questions/12481639/remove-fi
 [[access_unmerged_commits]]
 === Create a Branch That Accesses Unmerged Commits
 
-Because we use the topic-based approach, in most cases we can work autonomously and not need changes made by others. But in some situations you may need changes you or a coworker has committed but not yet merged. One example of this is if another write creates and adds a lot of new topics to the `docs/topics` directory and issues a merge request. If you need to make update the `main.adoc` with those topics, you need access to those new topics to test how they render in the build.
+Because we use the topic-based approach, in most cases we can work autonomously and not need changes made by others. But in some situations you may need changes you or a coworker has committed but not yet merged. One example of this is if another write creates and adds a lot of new topics to the `docs/topics` directory and issues a pull request. If you need to make update the `main.adoc` with those topics, you need access to those new topics to test how they render in the build.
 
 ==== Access Your Own Unmerged Commits
 
-This is the process you should use if you need commits you have submitted in a merge request that is not yet merged.
+This is the process you should use if you need commits you have submitted in a pull request that is not yet merged.
 
 . Check out a new topic branch from upstream/main as you normally do.
 +
@@ -1009,7 +1009,7 @@ $ git rebase origin/MERGE_REQUEST_BRANCH
 
 ==== Access Another Writer's Unmerged Commits
 
-.This is the process you should use if you need commits another writer has submitted in a merge request that is not yet merged.
+.This is the process you should use if you need commits another writer has submitted in a pull request that is not yet merged.
 
 . Check out a new topic branch from upstream/main as you normally do.
 +
@@ -1022,7 +1022,7 @@ $ git checkout -b NEW_TOPIC_BRANCH upstream/main
 +
 [source,options="nowrap"]
 ----
-$ git remote add -f <username> git@gitlab.cee.redhat.com:<username>/stonesoup-documentation.git
+$ git remote add -f <username> git@github.com:<username>/<remote repository name>.git
 ----
 . Rebase to bring in the changes that are in that user's outstanding `origin/MERGE_REQUEST_BRANCH` branch.
 +
@@ -1038,7 +1038,7 @@ $ git rebase <username>/MERGE_REQUEST_BRANCH
 
 When you are finished, you can commit and push your changes to origin HEAD. It will show the 2 commits: the one from the rebase and the one from your own changes. You don't need to worry about that because the administrator will resolve them at merge time.
 
-If the commit is merged by the time you check in your changes and you do want to resolve it before you issue the merge request, follow this process.
+If the commit is merged by the time you check in your changes and you do want to resolve it before you issue the pull request, follow this process.
 
 . Fetch the latest from upstream and rebase the branch to upstream/main.
 +
@@ -1066,13 +1066,13 @@ Applying: COMMIT_MESSAGE.
 [[review_another_writers_unmerged_commits]]
 ==== Review Another Writer's Unmerged Commits
 
-This is the process you should use if you need to review commits another writer has submitted in a merge request that is not yet merged.
+This is the process you should use if you need to review commits another writer has submitted in a pull request that is not yet merged.
 
-. If you have not yet added that writer's remote repository, add it now. The user's GitLab repository URL is displayed at the top of their repository page, for example, https://gitlab.cee.redhat.com/<username>/stonesoup-documentation
+. If you have not yet added that writer's remote repository, add it now. The user's GitHub repository URL is displayed at the top of their repository page, for example, https://github.com/<username>/docs.appstudio.io
 +
 [source,options="nowrap"]
 ----
-$ git remote add -f <username> git@gitlab.cee.redhat.com:<username>/stonesoup-documentation.git
+$ git remote add -f <username> git@github.com:<username>/docs.appstudio.io.git
 ----
 . If you had previously added the user's remote repository, you must now fetch the latest updates.
 +
@@ -1102,7 +1102,7 @@ $ git rebase upstream/main
 [[renaming_branches]]
 === Renaming Branches
 
-If you need to work in a topic branch for a while but are not ready to issue a merge request, you may want to name your branch in a way to indicate that it is not ready to be merged. For example:
+If you need to work in a topic branch for a while but are not ready to issue a pull request, you may want to name your branch in a way to indicate that it is not ready to be merged. For example:
 
 [source,options="nowrap"]
 ----
@@ -1125,7 +1125,7 @@ TIP: Renaming branches is also useful if you want to track large changes in stag
 [[deleting_branches]]
 === Deleting Branches
 
-Once your merge request has been merged into upstream and you no longer need a topic branch, you can delete the local branch and the corresponding remote origin repository branch. You also want to clean up the stale remote references.
+Once your pull request has been merged into upstream and you no longer need a topic branch, you can delete the local branch and the corresponding remote origin repository branch. You also want to clean up the stale remote references.
 
 WARNING: Once a branch has been deleted, it cannot be restored. Be certain that you no longer need any changes on the branch before deleting it!
 
@@ -1133,7 +1133,7 @@ WARNING: Once a branch has been deleted, it cannot be restored. Be certain that 
 
 . Open a browser and access your repository URL, for example:
 +
-https://gitlab.cee.redhat.com/<username>/stonesoup-documentation/
+https://github.com/<username>/docs.appstudio.io
 
 . The top right side of the page displays links for `commits`, `branches`, and `tags`. Select the *branches* link.
 . You are presented with a page listing the branches in your repository. Find the branch you want to delete and select the red trash can icon to remove it. You are presented with a dialog asking "Removed branch cannot be restored. Are you sure?". Select *OK* if you are sure you want to delete the branch.
@@ -1162,13 +1162,13 @@ $ git branch -d TOPIC_BRANCH
 error: The branch 'TOPIC_BRANCH' is not fully merged.
 If you are sure you want to delete it, run 'git branch -D TOPIC_BRANCH'.
 ----
-.. If your merge request to upstream was recently accepted, you may first need to fetch upstream for git to realize the changes were merged.
+.. If your pull request to upstream was recently accepted, you may first need to fetch upstream for git to realize the changes were merged.
 +
 ----
 $ git fetch upstream
 $ git branch -d TOPIC_BRANCH
 ----
-.. This can also happen if other changes were committed to the upstream repository after you checked out your branch but before you submitted the merge request. In this case the administrator might have had to rebase your merge request before merging and it doesn't recognize that it was merged. Verify that your commit is in the upstream repository before you continue with the delete.
+.. This can also happen if other changes were committed to the upstream repository after you checked out your branch but before you submitted the pull request. In this case the administrator might have had to rebase your pull request before merging and it doesn't recognize that it was merged. Verify that your commit is in the upstream repository before you continue with the delete.
 +
 ----
 $ git branch -D TOPIC_BRANCH
@@ -1197,7 +1197,7 @@ You remove remote tracking references using the `git remote prune REMOTE_NAME` c
 $ git remote prune origin
   x [deleted]         (none)     -> origin/TOPIC_BRANCH
   Pruning origin
-  URL: git@gitlab.cee.redhat.com:<username>/stonesoup-documentation.git
+  URL: git@github.com:<username>/docs.appstudio.io.git
    * [pruned] origin/TOPIC_BRANCH
 ----
 
@@ -1323,7 +1323,7 @@ You can also use 'git reset --hard origin/__BRANCH_NAME__' to reset your local b
 |git diff _FILE_NAME_
 |View the changes made to a file.
 
-|git remote add -f REMOTE_NAME git@gitlab.cee.redhat.com:USERNAME/stonesoup-documentation
+|git remote add -f REMOTE_NAME git@github.com:<username>/docs.appstudio.io
 |Add a remote repository for another user.
 
 |git branch -m CURRENT_BRANCH_NAME NEW_BRANCH_NAME
@@ -1606,11 +1606,11 @@ The _asciidoc-preview_ package is not the same as _asciidoctor-preview_. The _as
     icons: font
     numbered: ''
     source-highlighter: highlightjs
-    url-guide: https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/
+    url-guide: https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/
 
 *Product content attributes*
 
-    ProductName: stonesoup
+    ProductName: appstudio
     ProductShortName: ''
     ProductRelease: ''
     ProductVersion: ''


### PR DESCRIPTION
RHTAPBUGS-404
- replaced or commented out broken red-hat-stone-soup.pages.redhat.com links
- replaced stonesoup with appstudio in git-workflow-and-contributor-guide.adoc
- updated repo's README that could use a couple more updates (contact info and gitlab parts)