### PR TITLE
Adds doc for adding an integration test

### DIFF
--- a/docs/modules/ROOT/nav-how-to-guides.adoc
+++ b/docs/modules/ROOT/nav-how-to-guides.adoc
@@ -4,6 +4,7 @@
 ** Testing your application
 *** xref:how-to-guides/testing_applications/con_test-overview.adoc[Overview of {ProductName} Test components]
 *** xref:how-to-guides/testing_applications/surface-level_tests.adoc[Surface-level test]
+*** xref:how-to-guides/testing_applications/proc_adding_an_integration_test.adoc[Adding an integration test]
 ** Securing your supply chain
 *** xref:how-to-guides/Secure-your-supply-chain/proc_inspect_sbom.adoc[Inspecting SBOMs]
 *** xref:how-to-guides/Secure-your-supply-chain/proc_inspect-slsa-provenance.adoc[Downloading your SLSA provenance]

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_adding_an_integration_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_adding_an_integration_test.adoc
@@ -1,0 +1,31 @@
+= Adding an integration test
+
+You can add an integration test to ensure that individual components correctly integrate to form a whole application. {ProductName} runs integration tests on the container images of components before it deploys those images.     
+
+.Prerequisites
+
+* You have created an application in {ProductName}.
+
+.Procedure
+Complete the following steps in the {ProductName} console:
+
+. Open an existing application and go to the *Integration tests* tab.
+. Select *Add integration test*.
+. In the *Integration test name* field, enter a name of your choosing.
+. In the *GitHub URL* field, enter the URL of the GitHub repository that contains the test you want to use.
+. Optional: If you want to use a branch, commit, or version other than the default, specify the branch name, commit SHA, or tag in the *Revisions* field
+. In the *Path in repository* field, enter the path to the `.yaml` file that defines the test you want to use.
+. Optional: If you do not want the test to prevent the application from being deployed, then select *Mark as optional for release*. 
+. Select *Add integration test*.
+. Start a new build for any component you want to test.
+.. For components using the default build pipeline, go to the *Components* tab, select the three dots next to the name of the component, and select *Start new build*.
+.. For components with an upgraded build pipeline, make a commit to their GitHub repository.
+
+.Verification
+When the new build is finished:
+
+. Go to the *Integration tests* tab and select the highlighted name of your test.
+. Go to the *Pipeline runs* tab of that test and select the most recent run.
+.  On the *Details* page, you can see if the test succeeded for that component. Navigate to the other tabs for more details. 
+
+


### PR DESCRIPTION
This PR adds a new doc to the testing subsection of the how-tos. The new doc explains how to add an integration test in the UI.