### PR TITLE
Add section about data injection

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -104,7 +104,7 @@ Labels:
 
 * *`appstudio.openshift.io/application`*: contains the name of the application
 * *`appstudio.openshift.io/component`*: contains the name of the component
-* `appstudio.openshift.io/snapshot`: contains the name of the snapshot.
+* *`appstudio.openshift.io/snapshot`*: contains the name of the snapshot
 * `test.appstudio.openshift.io/optional`: contains the optional flag, which specifies whether or not components must pass the integration test before deployment.  
 * `test.appstudio.openshift.io/scenario`: contains the name of the integration test (this label ends with "scenario," because each test is technically a custom resource called an `IntegrationTestScenario`). 
 

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -103,7 +103,7 @@ Parameters:
 Labels:
 
 * `appstudio.openshift.io/application`: contains the name of the application.
-* `appstudio.openshift.io/component`: contains the name of the component.
+* *`appstudio.openshift.io/component`*: contains the name of the component
 * `appstudio.openshift.io/snapshot`: contains the name of the snapshot.
 * `test.appstudio.openshift.io/optional`: contains the optional flag, which specifies whether or not components must pass the integration test before deployment.  
 * `test.appstudio.openshift.io/scenario`: contains the name of the integration test (this label ends with "scenario," because each test is technically a custom resource called an `IntegrationTestScenario`). 

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -105,8 +105,8 @@ Labels:
 * *`appstudio.openshift.io/application`*: contains the name of the application.
 * *`appstudio.openshift.io/component`*: contains the name of the component.
 * *`appstudio.openshift.io/snapshot`*: contains the name of the snapshot.
-* `test.appstudio.openshift.io/optional`: contains the optional flag, which specifies whether or not components must pass the integration test before deployment.  
-* `test.appstudio.openshift.io/scenario`: contains the name of the integration test (this label ends with "scenario," because each test is technically a custom resource called an `IntegrationTestScenario`). 
+* *`test.appstudio.openshift.io/optional`*: contains the optional flag, which specifies whether or not components must pass the integration test before deployment.  
+* *`test.appstudio.openshift.io/scenario`*: contains the name of the integration test (this label ends with "scenario," because each test is technically a custom resource called an `IntegrationTestScenario`). 
 
 .Verification
 

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -97,14 +97,14 @@ When you create a custom integration test, {ProductName} automatically adds cert
 
 Parameters:
 
-* *`SNAPSHOT`*: contains the xref:../../glossary/index.adoc#_snapshot[snapshot] of the whole application as a JSON string. This JSON string provides useful information about the test, such as which components {ProductName} is testing, and what git repository and commit {ProductName} is using to build those components. For information about snapshot JSON string, see link:https://github.com/redhat-appstudio/integration-examples/blob/main/examples/snapshot_json_string_example[an example snapshot json string]
-* *`NAMESPACE`*:  adds the `namespace` parameter to indicate which namespace it uses for deployment only if your integration test specifies that {ProductName} should deploy a snapshot to an ephemeral environment during testing. This parameter can help you query Kubernetes resources that are deployed in the test environment, such as routes, deployments, and pods. 
+* *`SNAPSHOT`*: contains the xref:../../glossary/index.adoc#_snapshot[snapshot] of the whole application as a JSON string. This JSON string provides useful information about the test, such as which components {ProductName} is testing, and what git repository and commit {ProductName} is using to build those components. For information about snapshot JSON string, see link:https://github.com/redhat-appstudio/integration-examples/blob/main/examples/snapshot_json_string_example[an example snapshot JSON string].
+* *`NAMESPACE`*:  indicates which namespace {ProductName} uses for temporary deployment, but only if your integration test specifies that {ProductName} should deploy the snapshot to an ephemeral environment during testing. This parameter can help you query Kubernetes resources that are deployed in the test environment, such as routes, deployments, and pods. 
 
 Labels:
 
-* *`appstudio.openshift.io/application`*: contains the name of the application
-* *`appstudio.openshift.io/component`*: contains the name of the component
-* *`appstudio.openshift.io/snapshot`*: contains the name of the snapshot
+* *`appstudio.openshift.io/application`*: contains the name of the application.
+* *`appstudio.openshift.io/component`*: contains the name of the component.
+* *`appstudio.openshift.io/snapshot`*: contains the name of the snapshot.
 * `test.appstudio.openshift.io/optional`: contains the optional flag, which specifies whether or not components must pass the integration test before deployment.  
 * `test.appstudio.openshift.io/scenario`: contains the name of the integration test (this label ends with "scenario," because each test is technically a custom resource called an `IntegrationTestScenario`). 
 

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -102,7 +102,7 @@ Parameters:
 
 Labels:
 
-* `appstudio.openshift.io/application`: contains the name of the application.
+* *`appstudio.openshift.io/application`*: contains the name of the application
 * *`appstudio.openshift.io/component`*: contains the name of the component
 * `appstudio.openshift.io/snapshot`: contains the name of the snapshot.
 * `test.appstudio.openshift.io/optional`: contains the optional flag, which specifies whether or not components must pass the integration test before deployment.  

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -98,7 +98,7 @@ When you create a custom integration test, {ProductName} automatically adds cert
 Parameters:
 
 * *`SNAPSHOT`*: contains the xref:../../glossary/index.adoc#_snapshot[snapshot] of the whole application as a JSON string. This JSON string provides useful information about the test, such as which components {ProductName} is testing, and what git repository and commit {ProductName} is using to build those components. For information about snapshot JSON string, see link:https://github.com/redhat-appstudio/integration-examples/blob/main/examples/snapshot_json_string_example[an example snapshot json string]
-* `NAMESPACE`: If your integration test specifies that {ProductName} should deploy the snapshot to an ephemeral environment during testing, then {ProductName} adds this parameter to indicate which namespace it uses for that deployment. This parameter can help you query Kubernetes resources that are deployed in the test environment, such as routes, deployments, and pods. 
+* *`NAMESPACE`*:  adds the `namespace` parameter to indicate which namespace it uses for deployment only if your integration test specifies that {ProductName} should deploy a snapshot to an ephemeral environment during testing. This parameter can help you query Kubernetes resources that are deployed in the test environment, such as routes, deployments, and pods. 
 
 Labels:
 

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -91,6 +91,23 @@ spec:
 . Add your new custom test as an integration test in {ProductName}.
 .. For additional instructions on adding an integration test, see this document: xref:how-to-guides/testing_applications/proc_adding_an_integration_test.adoc[Adding an integration test].
 
+.Data injected into the PipelineRun of the integration test
+
+When you create a custom integration test, {ProductName} automatically adds certain parameters and labels to the PipelineRun of the integration test. This section explains what those parameters and labels are, and how they can help you.
+
+Parameters:
+
+* `SNAPSHOT`: contains the xref:../../glossary/index.adoc#_snapshot[snapshot] of the whole application as a JSON string. This JSON string provides useful information about the test, such as which components {ProductName} is testing, and what git repository and commit {ProductName} is using to build those components. Click link:https://github.com/redhat-appstudio/integration-examples/blob/main/examples/snapshot_json_string_example[here] to see an example of a snapshot JSON string.
+* `NAMESPACE`: If your integration test specifies that {ProductName} should deploy the snapshot to an ephemeral environment during testing, then {ProductName} adds this parameter to indicate which namespace it uses for that deployment. This parameter can help you query Kubernetes resources that are deployed in the test environment, such as routes, deployments, and pods. 
+
+Labels:
+
+* `appstudio.openshift.io/application`: contains the name of the application.
+* `appstudio.openshift.io/component`: contains the name of the component.
+* `appstudio.openshift.io/snapshot`: contains the name of the snapshot.
+* `test.appstudio.openshift.io/optional`: contains the optional flag, which specifies whether or not components must pass the integration test before deployment.  
+* `test.appstudio.openshift.io/scenario`: contains the name of the integration test (this label ends with "scenario," because each test is technically a custom resource called an `IntegrationTestScenario`). 
+
 .Verification
 
 After adding the integration test to an application, you need to trigger a new build of its components to make {ProductName} run the integration test. Make a commit to the GitHub repositories of your components to trigger a new build.

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -97,7 +97,7 @@ When you create a custom integration test, {ProductName} automatically adds cert
 
 Parameters:
 
-* `SNAPSHOT`: contains the xref:../../glossary/index.adoc#_snapshot[snapshot] of the whole application as a JSON string. This JSON string provides useful information about the test, such as which components {ProductName} is testing, and what git repository and commit {ProductName} is using to build those components. Click link:https://github.com/redhat-appstudio/integration-examples/blob/main/examples/snapshot_json_string_example[here] to see an example of a snapshot JSON string.
+* *`SNAPSHOT`*: contains the xref:../../glossary/index.adoc#_snapshot[snapshot] of the whole application as a JSON string. This JSON string provides useful information about the test, such as which components {ProductName} is testing, and what git repository and commit {ProductName} is using to build those components. For information about snapshot JSON string, see link:https://github.com/redhat-appstudio/integration-examples/blob/main/examples/snapshot_json_string_example[an example snapshot json string]
 * `NAMESPACE`: If your integration test specifies that {ProductName} should deploy the snapshot to an ephemeral environment during testing, then {ProductName} adds this parameter to indicate which namespace it uses for that deployment. This parameter can help you query Kubernetes resources that are deployed in the test environment, such as routes, deployments, and pods. 
 
 Labels:


### PR DESCRIPTION
This PR adds a new section to our page about creating a custom integration test. The new section describes parameters and labels that RHTAP/App Studio injects into the PipelineRuns of these tests, and how that data is relevant to users.  