### PR TITLE
Fixes explanation of temporary environments in step 7

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_adding_an_integration_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_adding_an_integration_test.adoc
@@ -15,9 +15,7 @@ Complete the following steps in the {ProductName} console:
 . In the *GitHub URL* field, enter the URL of the GitHub repository that contains the test you want to use.
 . Optional: If you want to use a branch, commit, or version other than the default, specify the branch name, commit SHA, or tag in the *Revisions* field
 . In the *Path in repository* field, enter the path to the `.yaml` file that defines the test you want to use.
-. Optional: If you want to run this test in parallel with other integration tests, use the drop-down menu in the *Environment* field to select *development*. 
-.. Running integration tests in parallel allows your components to progress through the testing pipeline faster. 
-.. This selection configures {ProductName} to clone the development environment, and run the integration test in that environment.
+. Optional: If you need to deploy your application as part of the test, use the drop-down menu in the *Environment* field to select *development*. {ProductName} then deploys your application to a temporary clone of that environment during testing.
 . Optional: If you do not want the test to prevent the application from being deployed, then select *Mark as optional for release*. 
 . Select *Add integration test*.
 . Start a new build for any component you want to test.


### PR DESCRIPTION
Previously, in step 7 of the procedure, I incorrectly explained the use of the temporary development environment. I thought that was how users configure RHTAP/App Studio to run tests in parallel. However, tests run in parallel automatically. This PR explains the actual reason why users would choose to clone the development environment: so RHTAP/App Studio can temporarily deploy a user's application during testing. 