### PR TITLE
Fixes bash commands in steps 2 and 3

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/Secure-your-supply-chain/proc_inspect-slsa-provenance.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/Secure-your-supply-chain/proc_inspect-slsa-provenance.adoc
@@ -34,7 +34,7 @@ partner-catalog-ec-pz7b      18d   True     OK       Updated
 +
 [source]
 --
-oc get component <component name> -ojson | jq ‘.status.containerImage’
+oc get component <component name> -ojson | jq '.status.containerImage'
 --
 
 +
@@ -42,11 +42,12 @@ Example:
 +
 [source]
 --
-`oc get component partner-catalog-build-ucmg -ojson | jq ‘.status.containerImage’
+oc get component partner-catalog-build-ucmg -ojson | jq '.status.containerImage'
 --
 
-. For convenience, save the image path to a local variable:
-
+. For convenience, save the image path to a local variable.
++
+Example:
 +
 [source]
 --


### PR DESCRIPTION
In the current version of the downloading SLSA provenance doc, there are apostrophes where there should be vertical ticks, like this: ' 
This PR fixes those, so users can copy and paste the commands from the doc, in step 2, and they won't get an error.