### PR TITLE
HACDOCS-509: Adding info about secrets to the Privacy notice

### DIFF
--- a/docs/modules/ROOT/pages/support/data-privacy.adoc
+++ b/docs/modules/ROOT/pages/support/data-privacy.adoc
@@ -19,6 +19,7 @@ When you create an application, {ProductName} stores the link to your GitHub rep
 == Secrets for sensitive data are available
 
 With {ProductName}, you can use build and deployment secrets to store sensitive data such as your credentials, API and encryption keys, access tokens, and more. Using secrets helps to secure your environments. We store secrets using AWS Secrets Manager.
+
 *Note:* Use secrets to store sensitive data. Do not enter any sensitive data in environment variables because App Studio stores such variables in a public GitOps repository.
 
 To create secrets, see the link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds[Creating secrets for your builds] guide.

--- a/docs/modules/ROOT/pages/support/data-privacy.adoc
+++ b/docs/modules/ROOT/pages/support/data-privacy.adoc
@@ -16,8 +16,11 @@ When you create an application, {ProductName} stores the link to your GitHub rep
 
 *Note:* There is no functionality to store the application configuration in a private GitOps repository. The artifacts created by {ProductName} are public and visible to anyone who is viewing the GitOps repository.
 
-== Data in deployment variables is public 
+== Secrets for sensitive data are available
 
-Developers often use deployment variables, also called environment variables, to store runtime configurations. These variables could contain sensitive data, such as database connections or credential information.
+With {ProductName}, you can use build and deployment secrets to store sensitive data such as your credentials, API and encryption keys, access tokens, and more. Using secrets helps to secure your environments. We store secrets using AWS Secrets Manager.
+*Note:* Use secrets to store sensitive data. Do not enter any sensitive data in environment variables because App Studio stores such variables in a public GitOps repository.
 
-*Note:* There is no functionality to secure sensitive data within a deployment variable. {ProductName} stores deployment variables in a public GitOps repository. Therefore, do not enter any sensitive data in deployment variables at all.
+To create secrets, see the link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds[Creating secrets for your builds] guide.
+
+// TODO add more secrets links when published

--- a/docs/modules/ROOT/pages/support/data-privacy.adoc
+++ b/docs/modules/ROOT/pages/support/data-privacy.adoc
@@ -18,10 +18,8 @@ When you create an application, {ProductName} stores the link to your GitHub rep
 
 == Secrets for sensitive data are available
 
-With {ProductName}, you can use build and deployment secrets to store sensitive data such as your credentials, API and encryption keys, access tokens, and more. Using secrets helps to secure your environments. We store secrets using AWS Secrets Manager.
+With {ProductName}, you can use build and deployment secrets to secure your environments and store sensitive data such as your credentials, API and encryption keys, access tokens, and more. We store secrets using AWS Secrets Manager.
 
-*Note:* Use secrets to store sensitive data. Do not enter any sensitive data in environment variables because App Studio stores such variables in a public GitOps repository.
-
-To create secrets, see the link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds[Creating secrets for your builds] guide.
+*Note:* Use secrets to store sensitive data. Do not enter any sensitive data in environment variables because App Studio stores such variables in a public GitOps repository. To create secrets, see link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds[Creating secrets for your builds].
 
 // TODO add more secrets links when published

--- a/docs/modules/ROOT/pages/support/data-privacy.adoc
+++ b/docs/modules/ROOT/pages/support/data-privacy.adoc
@@ -20,6 +20,6 @@ When you create an application, {ProductName} stores the link to your GitHub rep
 
 With {ProductName}, you can use build and deployment secrets to secure your environments and store sensitive data such as your credentials, API and encryption keys, access tokens, and more. We store secrets using AWS Secrets Manager.
 
-*Note:* Use secrets to store sensitive data. Do not enter any sensitive data in environment variables because App Studio stores such variables in a public GitOps repository. To create secrets, see link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds[Creating secrets for your builds].
+*Note:* Use secrets to store sensitive data. Do not enter any sensitive data in environment variables because {ProductName} stores such variables in a public GitOps repository. To create secrets, see link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds[Creating secrets for your builds].
 
 // TODO add more secrets links when published


### PR DESCRIPTION
HACDOCS-509: Updating [the privacy notice](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/support/data-privacy) with info about secrets.