### PR TITLE
HACDOCS-558: Update App studio documentation with npm package manager

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/proc_hermetic-builds.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/proc_hermetic-builds.adoc
@@ -1,15 +1,32 @@
 :_content-type: PROCEDURE
-:myfunctionone: hermetic_builds
+:troubleshooting_builds:
 
 [id="hermetic-builds_{context}"]
 = Enabling hermetic builds
 
-Hermetic builds refer to a controlled build process in which a build system knows all the required resources and dependencies. This enhanced dependency visibility allows the build system to capture and produce a more precise record of the build's origin, dependencies, and modifications than it would otherwise be possible.
+A hermetic build is a secure, self-contained build process that doesn't depend on anything outside of the build environment. This means that it does not have network access, is not vulnerable to external influences, and cannot fetch dependencies at run time. Instead, you must declare all required resources and dependencies in your build definition. 
 
-In {ProductName}, hermetic builds are achieved by blocking network access to the build process. Therefore, you must pre-fetch all dependencies before the build can start.
+In {ProductName}, you can block network access to the build process and run a hermetic build by setting the `*hermetic*` parameter in your pipeline definition file to `true`. This means that you must fetch all dependencies _before_ the build can start. The following is an example code snippet:
 
-IMPORTANT: Hermetic builds disable network access, so the builds that require dependencies outside its Git repository could fail.
+[source,yaml]
+----
+kind: PipelineRun
+spec:
+  params:
+    ...
+  - name: hermetic
+    value: "true"
+    ...
+----
 
+[IMPORTANT]
+====
+* Hermetic builds disable network access, so a build with dependencies outside of its Git repository--including supported languages--might fail. To prevent this, or to pull in dependencies from a package manager for one of the xref:how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build.adoc#supported-languages[supported languages], follow the instructions in link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build/[Prefetching the package manager dependencies for the hermetic build].
++
+Similarly, with a link:https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml[Buildah] task for a non-Java application, when you set the `*hermetic*` parameter to `true`, you’re isolating the build from the network, which restricts it to building only from dependencies listed in your Git repository. 
+
+* Do not add these parameters to the link:https://github.com/burrsutter/partner-catalog-stage/blob/e2ebb05ba8b4e842010710898d555ed3ba687329/.tekton/partner-catalog-stage-wgxd-pull-request.yaml#L87[`**pipelineSpec.params**`] section, as it should always display the default values for hermetic builds.
+====
 
 .Prerequisites
 
@@ -19,9 +36,9 @@ IMPORTANT: Hermetic builds disable network access, so the builds that require de
 
 To create a hermetic build for a component, complete the following steps:
 
-. Go to the `.tekton` directory in the repository of your component and locate the *.yaml* files related to the *pull-request* and *push* processes.
+. Go to the `.tekton` directory in your component's repository and find the `.yaml` files related to your `*pull request*` and `*push*` processes.
 
-. To configure the hermetic pipeline in both the *.yaml* files, add the following hermetic pipeline parameters to the `spec.params` section:
+. To configure the hermetic pipeline in both the `.yaml` files, add the following hermetic pipeline parameters to the `spec.params` section:
 
 +
 [source,yaml]
@@ -30,25 +47,24 @@ spec:
     params:
         -   ...
         -   name: hermetic
-            value: “true”
+            value: "true"
 ----
 
 +
-[NOTE]
-====
-* In a non-java application, that is a link:https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml[Buildah] task, adding the parameter mentioned above automatically isolates the build from the network, restricting it to only build from dependencies listed in your Git repository. If you need to pull in dependencies from a package manager for one of the xref:how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build.adoc#supported-languages[supported languages], see xref:how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build.adoc[Prefetching the package manager dependencies for the Hermetic build].
+. Commit your changes to the component repository and create a pull request.
 
-* Do not add these parameters to the link:https://github.com/burrsutter/partner-catalog-stage/blob/e2ebb05ba8b4e842010710898d555ed3ba687329/.tekton/partner-catalog-stage-wgxd-pull-request.yaml#L87[`pipelineSpec.params`] section, as it should always display the default values for hermetic builds.
-====
-. Create a pull request (PR) by committing your changes to the repository of the component.
+. Verify that your build was successful, then merge your pull request.
 
-. Review and merge the PR.
+.Verification
+* From the {ProductName} *Applications* view, go to *Activity > Pipeline runs*.
+** Look at the pipeline run with *Build* in the *Type* column and confirm that the `build-container` stage displays a green checkmark. This indicates that the build process successfully fetched all dependencies.
+* From the {ProductName} *Applications* view, go to *Activity > Latest commits*.
 
-include::../partials/con_hermetic_verification.adoc[]
+include::../partials/con_hermetic_troubleshooting.adoc[]
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 
-* For more information on the importance of provenance, see link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/concepts/slsa/con_slsa-conformity/[Supply chain security through SLSA conformity].
+For more information about the importance of provenance, see link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/concepts/slsa/con_slsa-conformity/[Supply chain security through SLSA conformity].
 
-* For more information on prefetching package manager dependencies, see the xref:how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build.adoc[Prefetching package manager dependencies for hermetic build]
+//JS adding a nothing comment to get my latest changes to show. Ugh

--- a/docs/modules/ROOT/pages/how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build.adoc
@@ -1,39 +1,41 @@
 :_content-type: PROCEDURE
-:myfunctiontwo: prefetch_hermetic_builds
+:troubleshooting_builds:
 
 [id="prefetching-dependencies-to-support-hermetic-build_{context}"]
-= Prefetching the package manager dependencies for the hermetic build
+= Prefetching package manager dependencies for a hermetic build
 
-In {ProductName}, hermetic builds are achieved by restricting network access to the build. Consequently, builds using supported languages may fail if they cannot retrieve dependencies from repositories. To address this, {ProductName} uses Cachi2 to prefetch the package manager dependencies for the supported-languages. Cachi2 makes it easier for package managers to prefetch dependencies. It also helps generate a manifest of all dependencies included in your builds, ensuring transparency and maintainability.
+In {ProductName}, you can run a hermetic build by restricting network access to the build. Consequently, a build might fail if it can't retrieve dependencies from a repository. To address this, {ProductName} uses Cachi2 to prefetch package manager dependencies for supported languages. For every build, Cachi2 also generates a software bill of materials (SBOM) of all dependencies included in your builds, for better transparency and build maintainability. For more information about SBOMs, see link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/Secure-your-supply-chain/proc_inspect_sbom/[Inspecting SBOMs].
 
 [#supported-languages]
 .Supported languages
 
 [cols="1,1"]
 |===
-|Language
-|Package Manager
+|**Language**
+|**Package manager**
 
 |Go
 |`gomod`
 
 |Python
 |`pip`
+
+|Node.js
+|`npm`
 |===
+
 
 == Enabling prefetch builds for `gomod`
 
 .Prerequisites
 * You have an link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_upgrade_build_pipeline/[upgraded build pipeline].
-
 * You have a `go.mod` file in your repository that lists all the dependencies.
 
-.Procedures
+.Procedure
 To create a hermetic build for a component, complete the following steps:
 
-. Go to the `.tekton` directory in the repository of your component and locate the *.yaml* files related to the *pull-request* and *push* processes.
-
-. To configure the hermetic pipeline in both the *.yaml* files, add the following hermetic pipeline parameters to the `spec.params` section:
+. Go to the `.tekton` directory in your component repository and find the `.yaml` files related to both the `*pull request*` and `*push*` processes.
+. To configure the hermetic pipeline in both `.yaml` files, add the following hermetic pipeline parameters to the `spec.params` sections:
 
 +
 [source,yaml]
@@ -44,30 +46,31 @@ spec:
         -   name: prefetch-input
             value: '{"type": "gomod", "path": "."}' <1>
 ----
-<1> The `prefetch-input` parameter specifies the path to the directory that has the lockfile and the package metadata files. In the above example, the `.` indicates that the package manager lock file is located in the root of the repository. Additionally, if you have multiple directories, you can provide the path to those directories in the JSON array format. For example, `[{"path": ".", "type": "gomod"}, {"path": "subpath/to/the/other/directory", "type": "gomod"}]`.
+<1> The `*prefetch-input*` parameter specifies the path to the directory that has the lockfile and the package metadata files. In this example, the `.` indicates that the package manager lockfile is in the repository root. Additionally, if you have multiple directories, you can provide the path to those directories in the JSON array format. For example, `[{"path": ".", "type": "gomod"}, {"path": "subpath/to/the/other/directory", "type": "gomod"}]`.
 
-+
-NOTE: Do not add these parameters to the link:https://github.com/burrsutter/partner-catalog-stage/blob/e2ebb05ba8b4e842010710898d555ed3ba687329/.tekton/partner-catalog-stage-wgxd-pull-request.yaml#L87[`pipelineSpec.params`] section, as it should always display the default values for hermetic builds.
+. Create a pull request by committing your changes to the repository of the component.
 
-. Create a pull request (PR) by committing your changes to the repository of the component.
+. Review and merge the pull request.
 
-. Review and merge the PR.
-
-include::../partials/con_hermetic_verification.adoc[]
+.Verification
+* From the {ProductName} *Applications* view, go to *Activity > Pipeline runs*.
+** Go to the pipeline run with *Build* in the *Type* column and confirm that the `pre-fetch dependencies` stage displays a green checkmark. This indicates that the build process successfully fetched all dependencies.
+* From the {ProductName} *Applications* view, go to *Activity > Latest commits*.
+//include::../partials/con_hermetic_verification.adoc[]
 
 == Enabling prefetch builds for `pip`
-Cachi2 supports pip by parsing of `pip` requirements files, including but not limited to, *requirements.txt* files placed in the root of your repository. By generically parsing `pip` requirements files, Cachi2 downloads the specified dependencies.
+Cachi2 supports pip by parsing of `pip` requirements files, including but not limited to, `requirements.txt` files placed in the root of your repository. By generically parsing `pip` requirements files, Cachi2 downloads the specified dependencies.
 
-IMPORTANT: The requirements file can have a different name, as you can use multiple files to provide the dependencies. These requirements files function as lock files, encompassing all the transitive dependencies. You must actively pin each transitive dependency listed in the requirements file to a specific version.
+IMPORTANT: The requirements file can have a different name because you can use multiple files to provide the dependencies. These requirements files function as lockfiles, encompassing all transitive dependencies. You must actively pin each transitive dependency listed in the requirements file to a specific version.
 
 .Prerequisites
 * You have an link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_upgrade_build_pipeline/[upgraded build pipeline].
 
-* You have an environment that closely matches the environment in the container build, meaning it has the same operating system and the same python $major.$minor version.
+* You have an environment that closely matches the environment in the container build, meaning it has the same operating system and the same python _$major.$minor_ version.
 
 * You have installed the link:https://github.com/jazzband/pip-tools[pip-tools] package.
 
-.Procedures
+.Procedure
 To create a hermetic build for a component, complete the following steps:
 
 . Download the link:https://raw.githubusercontent.com/containerbuildsystem/cachito/master/bin/pip_find_builddeps.py[pip_find_builddeps.py] script directly from GitHub.
@@ -92,7 +95,7 @@ chmod +x pip_find_builddeps.py
 
 . Go to your component's source code.
 
-. Review the root of your repository for a metadata file, for example, *pyproject.toml*, *setup.py*, or *setup.cfg*. If there is no metadata file, create one, as Cachi2 looks for the name and version of your project in the metadata files.
+. Review the root of your repository for a metadata file, for example, `pyproject.toml`, `setup.py`, or `setup.cfg`. If there is no metadata file, create one, because Cachi2 looks for the name and version of your project in the metadata files.
 
 +
 [source,metadata]
@@ -103,35 +106,35 @@ version = "0.1.0"
 ----
 
 +
-NOTE: Instead of a *pyproject.toml* file, you can also create a *setup.py* or *setup.cfg* file. For information on the metadata of these files, see link:https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#project-metadata[Project Metadata].
+NOTE: Instead of a `pyproject.toml` file, you can also create a `setup.py` or `setup.cfg` file. For information about the metadata of these files, see link:https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#project-metadata[Project metadata].
 
-. Generate a fully resolved *requirements.txt* file that contains all the transitive dependencies and pins them to a specific version and hash by using the following command:
+. Generate a fully resolved `requirements.txt` file that contains all the transitive dependencies and pins them to a specific version and hash by using the following command:
 
 +
 [source,command]
 ----
 $ pip-compile pyproject.toml --generate-hashes
 ----
-
 +
 [NOTE]
 ==== 
-* To successfully run the command mentioned above your environment must be as close as possible to the environment in the container build. That is, the environment should have the same operating system and the same Python $major.$minor version.
+* To successfully run the previous command, your environment must be as close as possible to the environment in the container build. That is, the environment should have the same operating system and the same Python _$major.$minor_ version.
 
-* The above-mentioned command assumes that you have defined project dependencies in *pyproject.toml*. However, if you have defined the project dependencies in either the *setup.py*, *requirements.txt*, or *requirements.in* files, ensure to update the command accordingly.
+* The previous command assumes that you have defined project dependencies in `pyproject.toml`. However, if you have defined the project dependencies in either the `setup.py`, `requirements.txt`, or `requirements.in` files, make sure you update the command accordingly.
 ====
++
+. Add the `requirements.txt` file to the root of your component source code. 
 
-. Add the *requirements.txt* to the root of your component’s source code. 
+. In the root of your repository create a `requirements-build.in` file.
 
-. In the root of your repository create a file, *requirements-build.in*.
-
-. Copy the build system requirements from the *pyproject.toml* file to the *requirements-build.in* file.
-
+. Copy the build system requirements from the `pyproject.toml` file to the `requirements-build.in` file.
+////
 +
 *For example:*
 +
 image::build-requirements.png[Build requirements, role="image"]
-
+////
+[start=10]
 . Run the `pip_find_builddeps.py` script and `pip-compile` the outputs by using the following command:
 
 +
@@ -143,7 +146,7 @@ $ pip_find_builddeps.py requirements.txt \
 -o requirements-build.in
 ----
 
-. Use the `pip-compile` command to convert the *requirements-build.in* file in to the *requirements-build.txt* file by using the following command:
+. Use the `pip-compile` command to convert the `requirements-build.in` file in to the `requirements-build.txt` file by using the following command:
 
 +
 [source,command]
@@ -151,16 +154,16 @@ $ pip_find_builddeps.py requirements.txt \
 $ pip-compile requirements-build.in --allow-unsafe --generate-hashes
 ----
 
-. Add the *requirement-build.txt* file to your project. It does not require any changes to your build process. 
+. Add the `requirement-build.txt` file to your project. It does not require any changes to your build process. 
 
 +
-NOTE: `pip` automatically installs the build dependencies when needed for explicit installation. The purpose of the *requirement-build.txt* file is to enable Cachi2 to fetch the build dependencies and provide them to `pip` for offline installation in a network-isolated environment.
+NOTE: `pip` automatically installs the build dependencies when needed for explicit installation. The purpose of the `requirement-build.txt` file is to enable Cachi2 to fetch the build dependencies and provide them to `pip` for offline installation in a network-isolated environment.
 
-. Go to the `.tekton` directory and locate the *.yaml* files related to the *pull-request* and *push* processes.
+. Go to the `.tekton` directory and locate the `.yaml` files related to the `*pull request*` and `*push*` processes.
 
 . Configure the hermetic pipeline.
 
-.. Add the following hermetic pipeline parameters in both the *.yaml* files:
+.. Add the following hermetic pipeline parameters in both the `.yaml` files:
 
 +
 [source,yaml]
@@ -171,17 +174,17 @@ spec:
         -   name: prefetch-input
             value: '{"type": "pip", "path": "."}' <1>
 ----
-<1> The `prefetch-input` parameter specifies the path to the directory that has the lockfile and the package metadata files. In the above example, the `.` indicates that the package manager lock file is located in the root of the repository. Additionally, if you have multiple directories, you can provide the path to those directories in the JSON array format. For example, `[{"path": ".", "type": "pip"}, {"path": "subpath/to/the/other/directory", "type": "pip"}]`.
+<1> The `*prefetch-input*` parameter specifies the path to the directory that has the lockfile and the package metadata files. In the previous example, the `.` indicates that the package manager lockfile is located in the root of the repository. Additionally, if you have multiple directories, you can provide the path to those directories in the JSON array format. For example, `[{"path": ".", "type": "pip"}, {"path": "subpath/to/the/other/directory", "type": "pip"}]`.
 
 +
 [NOTE]
 ====
 * By default, Cachi2 processes `requirements.txt` and `requirements-build.txt` at a specified path.
 
-* When adding the parameters mentioned above, you can safely ignore the default values for the link:https://github.com/burrsutter/partner-catalog-stage/blob/e2ebb05ba8b4e842010710898d555ed3ba687329/.tekton/partner-catalog-stage-wgxd-pull-request.yaml#L90[`pipelineSpec.params`] in the *.yaml* files.
+* When adding these parameters, you can safely ignore the default values for the link:https://github.com/burrsutter/partner-catalog-stage/blob/e2ebb05ba8b4e842010710898d555ed3ba687329/.tekton/partner-catalog-stage-wgxd-pull-request.yaml#L90[`pipelineSpec.params`] in the `.yaml` files.
 ====
 
-.. Optional: For requirements files with non-default names and path, add the following hermetic pipeline parameters in both the *.yaml* files:
+.. Optional: For requirements files without default names and path, add the following hermetic pipeline parameters in both the `.yaml` files:
 
 +
 [source,yaml]
@@ -192,18 +195,57 @@ spec:
         -   name: prefetch-input
             value: '{"type": "pip", "path": ".", "requirements_files": ["requirements.txt", "requirements-extras.txt", "tests/requirements.txt"]}' <1>
 ----
-<1> The `prefetch-input` parameter specifies the path to the directory that has the lockfile and the package metadata files. In the above example, the `.` indicates that the package manager lock file is located in the root of the repository. Additionally, if you have multiple directories, you can provide the path to those directories in the JSON array format. For example, `[{"path": ".", "type": "pip", , "requirements_files": ["requirements.txt", "requirements-extras.txt", "tests/requirements.txt"]}, {"path": "subpath/to/the/other/directory", "type": "pip", "requirements_files": ["requirements.txt", "requirements-extras.txt", "tests/requirements.txt"]}]`.
+<1> The `*prefetch-input*` parameter specifies the path to the directory that has the lockfile and the package metadata files. In the previous example, the `.` indicates that the package manager lockfile is located in the root of the repository. Additionally, if you have multiple directories, you can provide the path to those directories in the JSON array format. For example, `[{"path": ".", "type": "pip", , "requirements_files": ["requirements.txt", "requirements-extras.txt", "tests/requirements.txt"]}, {"path": "subpath/to/the/other/directory", "type": "pip", "requirements_files": ["requirements.txt", "requirements-extras.txt", "tests/requirements.txt"]}]`.
 
 +
-. Create a PR by committing your changes to the repository of the component.
+. Create a pull request by committing your changes to the repository of the component.
 
-. Review and merge the PR.
+. Review and merge the pull request.
 
-include::../partials/con_hermetic_verification.adoc[]
+.Verification
+* From the {ProductName} *Applications* view, go to *Activity > Pipeline runs*.
+** Go to the pipeline run with *Build* in the *Type* column and confirm that the `pre-fetch dependencies` stage displays a green checkmark. This indicates that the build process successfully fetched all dependencies.
+* From the {ProductName} *Applications* view, go to *Activity > Latest commits*.
+//include::../partials/con_hermetic_verification.adoc[]
+
+== Enabling prefetch builds for `npm`
+Cachi2 supports `npm` by fetching any dependencies you declare in your `package.json` and `package-lock.json` project files. The npm CLI manages the `package-lock.json` file automatically, and Cachi2 fetches any dependencies and enables your build to install them without network access.
+
+.Prerequisites
+* You have an link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/configuring-builds/proc_upgrade_build_pipeline/[upgraded build pipeline].
+* You have an up-to-date link:https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json[`package-lock.json`] file, newer than version 1, in your source repository. To make sure that you have the latest `package-lock.json` file, or to create a lockfile, run the link:https://docs.npmjs.com/cli/v9/commands/npm-install?v=true[`npm-install`] command. You can also look at the `lockfileVersion` attribute in your `package-lock.json` file to make sure its value is a number greater than `*1*`. 
+
+.Procedure
+To create a hermetic build for a component, complete the following steps:
+
+. Go to the `.tekton` directory and find the `.yaml` files related to the `*pull request*` and `*push*` processes.
+. Configure the hermetic pipeline by adding the following parameters in both `.yaml` files:
+
++
+[source,yaml]
+----
+spec:
+    params:
+        -   ...
+        -   name: prefetch-input
+            value: '{"type": "npm", "path": "."}' <1>
+---- 
+<1> The `*prefetch-input*` parameter specifies the path to the directory that has the lockfile and the package metadata files. In this example, the `.` indicates that the package manager lockfile is in the repository root. Additionally, if you have multiple directories, you can provide the path to those directories in the JSON array format. For example, `[{"path": ".", "type": "npm"}, {"path": "subpath/to/the/other/directory", "type": "npm"}]`.
+
+. Create a pull request by committing your changes to the repository of the component.
+. Review and merge the pull request.
+
+.Verification
+* From the {ProductName} *Applications* view, go to *Activity > Pipeline runs*.
+** Go to the pipeline run with *Build* in the *Type* column and confirm that the `pre-fetch dependencies` stage displays a green checkmark. This indicates that the build process successfully fetched all dependencies.
+* From the {ProductName} *Applications* view, go to *Activity > Latest commits*.
+
+include::../partials/con_hermetic_troubleshooting.adoc[]
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 
-* To troubleshoot any issues you experience when working with Enabling prefetch builds for `pip` or `pip` with source dependencies, see the link:https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#troubleshooting[Troubleshooting] section.
+* To troubleshoot any issues you might experience when you enable prefetch builds for `pip` or `pip` with source dependencies, see link:https://github.com/containerbuildsystem/cachi2/blob/main/docs/pip.md#troubleshooting[Troubleshooting].
+* For more information about Cachi2, see link:https://github.com/containerbuildsystem/cachi2/blob/main/README.md[Cachi2].
 
-* For more information about Cachi2, see link:https://github.com/containerbuildsystem/cachi2/blob/main/README.md[Cachi2] documentation.
+//JS adding a nothing comment to get my latest changes to show. Ugh

--- a/docs/modules/ROOT/pages/partials/con_hermetic_troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/partials/con_hermetic_troubleshooting.adoc
@@ -1,0 +1,12 @@
+.Troubleshooting
+
+ifdef::troubleshooting_builds[]
+
+If your build fails, be sure to look at your logs:
+
+In {ProductName}, from the *Applications* view, select the application build you want to troubleshoot, then from the resulting *Overview* page, select the *Activity* tab. From there, under *Activity By*, select *Pipeline runs*. From the *Name* column, select the build whose logs you want to check, then from the resulting *Pipeline run details* view, do one of the following:
+
+* Select the *Logs* tab.
+* Alternatively, you can click *build-container*. When the right panel opens, select the *Logs* tab to see a partial view of the log for that build.
+
+endif::troubleshooting_builds[]

--- a/docs/modules/ROOT/pages/partials/con_hermetic_verification.adoc
+++ b/docs/modules/ROOT/pages/partials/con_hermetic_verification.adoc
@@ -1,16 +1,33 @@
 .Verification
 
-. On your application, go to the *Activity > Pipeline runs* tab.
+* From the {ProductName} *Applications* view, go to *Activity > Latest commits*.
+* From the {ProductName} *Applications* view, go to *Activity > Pipeline runs*.
 
 ifdef::myfunctionone[]
 
-. Go to the pipeline run with *Type* as *Build* and confirm the `build-container` stage displays a green check mark indicating that the build process has successfully fetched all the dependencies.
+** Look at the pipeline run with *Build* in the *Type* column and confirm that the `build-container` stage displays a green checkmark. This indicates that the build process successfully fetched all dependencies.
 
 endif::[]
 
 ifdef::myfunctiontwo[]
 
-. For a pipeline run with *Type* as *Build* and confirm the `pre-fetch dependencies` stage displays a green check mark indicating that the build process has successfully pre-fetched all the dependencies.
+* Go to the pipeline run with *Build* in the *Type* column and confirm that the `pre-fetch dependencies` stage displays a green checkmark. This indicates that the build process successfully fetched all dependencies.
+
+endif::[]
+
+ifdef::prefetch[]
+
+* From the {ProductName} *Applications* view, go to *Activity > Pipeline runs*.
+** Go to the pipeline run with *Build* in the *Type* column and confirm that the `pre-fetch dependencies` stage displays a green checkmark. This indicates that the build process successfully fetched all dependencies.
+* From the {ProductName} *Applications* view, go to *Activity > Latest commits*.
+
+endif::[]
+
+ifdef::enable[]
+
+* From the {ProductName} *Applications* view, go to *Activity > Pipeline runs*.
+** Look at the pipeline run with *Build* in the *Type* column and confirm that the `build-container` stage displays a green checkmark. This indicates that the build process successfully fetched all dependencies.
+* From the {ProductName} *Applications* view, go to *Activity > Latest commits*.
 
 endif::[]
 


### PR DESCRIPTION
[HACDOCS-558](https://issues.redhat.com/browse/HACDOCS-558)

Per @nirzari's request, adding content related to new support by RHTAP of npm package mgr.