### PR TITLE
integration tests: Add warning about not specifying environment

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_adding_an_integration_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_adding_an_integration_test.adoc
@@ -16,7 +16,9 @@ Complete the following steps in the {ProductName} console:
 . Optional: If you want to use a branch, commit, or version other than the default, specify the branch name, commit SHA, or tag in the *Revisions* field
 . In the *Path in repository* field, enter the path to the `.yaml` file that defines the test you want to use.
 . Optional: If you need to deploy your application as part of the test, use the drop-down menu in the *Environment* field to select *development*. {ProductName} then deploys your application to a temporary clone of that environment during testing.
-. Optional: If you do not want the test to prevent the application from being deployed, then select *Mark as optional for release*. 
++
+WARNING: Without specifying an Environment, an integration test can only do static testing. To make application endpoints available for testing, you must deploy your application to an ephemeral environment.
+. Optional: If you do not want the test to prevent the application from being deployed, then select *Mark as optional for release*.
 . Select *Add integration test*.
 . Start a new build for any component you want to test.
 .. For components using the default build pipeline, go to the *Components* tab, select the three dots next to the name of the component, and select *Start new build*.


### PR DESCRIPTION
It's not clear from doc, how important is the field Environment. Adding warning to get user attention.