### PR TITLE
HACDOCS-630: Updated Add secret upstream content to match UI

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds.adoc
@@ -4,10 +4,20 @@ When you build your application, create secrets to ensure the `sast_snyk_task` w
 
 .Procedure 
 
-. In the {ProductName}, go to the *Components* tab of your application.
-. Select the three dots next to the component you want to configure, and select *Edit component settings*. 
-. Under *Secrets*, click *Add secret*. The secret modal opens and is called, *Create new build secret*.
-. Under *Select or enter name*, use the predefined `snyk_secret` or create a custom secret. 
-. Fill in the *Key* and *Value* fields. 
-. Click *Create*. The secret modal closes. 
-. In the {ProductName}, click *Save*. 
+. In {ProductName}, from the left navigation menu, select **Secrets**.
+. From the **Secrets** page, click **Add secret**.
+. From the **Add secret** page, choose what stage of your application's development you want to create a secret for: **Build** or **Deployment**.
+. Select a secret type:
+    * **Key/value secret**
+    * **Image pull secret**
+    * **Source secret**
+. For **Secret name**, enter a unique name for your secret.
+. Under **Key/value secret**, expand **Key/value 1**, then enter a key.
+. For **Upload the file with value for your key or paste its contents**, do one of the following:
+    * Click **Upload** to browse to, select, and upload the file that contains your key value.
+    * Drag the file that contains your key value into the space under **Upload**.
+    * Paste the contents of the file that contains your key value into the space under **Upload**.
+  Click **Clear** to remove the contents of the space under **Upload**.
+. Optional: Click **Add another key/value**.
+. Optional: Under **Labels**, add a label to tag or provide more context for your secret.
+. Click **Add secret**.


### PR DESCRIPTION
[HACDOCS-630](https://issues.redhat.com/browse/HACDOCS-630)

@karthikjeeyar rightly pointed out in my [PR for HACDOCS-508](https://github.com/redhat-appstudio/docs.appstudio.io/pull/195) that we also need to update the upstream content for adding secrets to reflect the latest state of the UI.