### PR TITLE
Clean up the top of the secrets how-to-guide

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds.adoc
@@ -1,6 +1,8 @@
 = Creating secrets for your builds 
 
-When you build your application, create secrets to ensure the `sast_snyk_task` works. The `sast_snyk_task` analyzes your source code to find vulnerabilities. The `sast_synk_task` secret defines parameters for your build pipeline. Add these `sast_snyk_task` secrets to your build pipeline to ultimately help build and deploy your application. 
+When you building your pipelines, you might want to add tasks that require *secrets* in order to access external resources.
+
+NOTE: One such task is the link:https://github.com/redhat-appstudio/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `sast_snyk_task` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
 
 .Procedure 
 


### PR DESCRIPTION
This is now a general doc about uploading secrets.

The main purpose of the change here is to kind of push the information about the name of the snyk secret into an aside, a note, so that it doesn't get in the main way of the thrust of the document.

It's still important. Users still need to know it. But, it's not central to the doc.

Also, I tried to improve the explanatory language around the snyk secret.

This is for https://issues.redhat.com/browse/KONFLUX-2042