### PR TITLE
`JBSConfig` `spec.enableRebuilds` in body must be of type boolean

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/Secure-your-supply-chain/proc_java_dependencies.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/Secure-your-supply-chain/proc_java_dependencies.adoc
@@ -115,7 +115,7 @@ kind: JBSConfig
 metadata:
   name: jvm-build-config
 spec:
-  enableRebuilds: "true"
+  enableRebuilds: true
 ----
 
 . Run `kubectl apply -f config.yaml`
@@ -139,7 +139,7 @@ kind: JBSConfig
 metadata:
   name: jvm-build-config
 spec:
-  enableRebuilds: "true" <1>
+  enableRebuilds: true <1>
   registry:
    host: quay.io <2>
    owner: OrgID <3>


### PR DESCRIPTION
Fix error:
```
The JBSConfig "jvm-build-config" is invalid: spec.enableRebuilds: Invalid value: "string": spec.enableRebuilds in body must be of type boolean: "string"
```