### PR TITLE
Update roles to use "admin" role name instead of non existing "owner" role

### DIFF
--- a/docs/modules/ROOT/pages/getting-started/roles_permissions.adoc
+++ b/docs/modules/ROOT/pages/getting-started/roles_permissions.adoc
@@ -4,7 +4,7 @@ As a workspace owner, you can add a collaborator to your workspace with their us
 
 * *Contributor*: For users who actively push code to your workspace but who don't need to manage workspace configuration.
 * *Maintainer*: For users who need to manage the workspace without access to sensitive actions like managing security.
-* *Owner*: For users who need full access to the workspace, including sensitive actions like managing security.
+* *Admin*: For users who need full access to the workspace, including sensitive actions like managing security.
 
 NOTE: By default, the role for newly invited collaborators is *Contributor*, but you can change this.
 
@@ -22,7 +22,7 @@ NOTE: By default, the role for newly invited collaborators is *Contributor*, but
 . Under **Assign role**, choose one of the following roles for your new workspace user:
 * **Contributor**
 * **Maintainer**
-* **Owner**
+* **Admin**
 . Click **Grant access**.
 
 .Verification
@@ -39,12 +39,12 @@ A message displays that reads, "You invited the user `_username_` to collaborate
 
 == Permissions for each role
 
-The role assigned to a user determines the permissions they have within a workspace. Users with the **Owner** role can assign permissions. 
+The role assigned to a user determines the permissions they have within a workspace. Users with the **Admin** role can assign permissions. 
 
 NOTE: Only an {ProductName} administrator can delete a workspace.
 
 |===
-|Permissions for |Action |Contributor |Maintainer |Owner
+|Permissions for |Action |Contributor |Maintainer |Admin
 
 .4+|Workspace
 |View

--- a/docs/modules/ROOT/pages/how-to-guides/managing-workspaces/proc-creating_a_team_workspace.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/managing-workspaces/proc-creating_a_team_workspace.adoc
@@ -26,7 +26,7 @@ NOTE: For the email address, choose an address that you can access. Use a team m
 
 . Once the account is created, use it to log in to https://console.redhat.com/preview/hac/application-pipeline[{ProductName}].
 . As in xref:getting-started/get-started.adoc[Getting started], join the waitlist.
-. Once approved, visit the link:https://console.redhat.com/preview/application-pipeline/access[User Access] section of the user interface to grant the xref:getting-started/roles_permissions.adoc[owner role] to your normal user identity.
+. Once approved, visit the link:https://console.redhat.com/preview/application-pipeline/access[User Access] section of the user interface to grant the xref:getting-started/roles_permissions.adoc[admin role] to your normal user identity.
 . link:https://www.redhat.com/wapps/ugc/sso/logout[Log out] and log back in as your normal user identity, and confirm you have access to the team workspace via the workspace switcher.
 
 NOTE: Once your normal user identity is granted admin, you should be able to add and manage other team members' access as your normal user identity by using the *User Access* section of the user interface.


### PR DESCRIPTION
Currently the roles & permissions overview lists the "Owner" role. Anyhow, this role is not available in the [User Access](https://console.redhat.com/preview/application-pipeline/access) page and "Admin" seems to be used instead.

This PR addresses this and renames the "Owner" role into "Admin" role and does this on the "Creating a team workspace" too.