### PR TITLE
feat(STONEINTG-698): remove references to ephemeral environments

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_adding_an_integration_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_adding_an_integration_test.adoc
@@ -15,9 +15,6 @@ Complete the following steps in the {ProductName} console:
 . In the *GitHub URL* field, enter the URL of the GitHub repository that contains the test you want to use.
 . Optional: If you want to use a branch, commit, or version other than the default, specify the branch name, commit SHA, or tag in the *Revisions* field
 . In the *Path in repository* field, enter the path to the `.yaml` file that defines the test you want to use.
-. Optional: If you need to deploy your application as part of the test, use the drop-down menu in the *Environment* field to select *development*. {ProductName} then deploys your application to a temporary clone of that environment during testing.
-+
-WARNING: Without specifying an Environment, an integration test can only do static testing. To make application endpoints available for testing, you must deploy your application to an ephemeral environment.
 . Optional: To allow the integration tests to fail without impacting the deployment and release process of your application, you can choose to select *Mark as optional for release*.
 +
 NOTE: By default, all integration test scenarios are mandatory and must pass. A failing integration test marks the application snapshot as failed, preventing its deployment and release. However,  if you have selected *Mark as optional for release*, a failure in this test won't hinder the deployment and release of the application snapshot.

--- a/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/testing_applications/proc_creating_custom_test.adoc
@@ -33,17 +33,6 @@ spec:
       name: SNAPSHOT
       default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
       type: string
-    - description: 'Namespace where the application is running'
-      name: NAMESPACE
-      default: "default"
-      type: string
-    - description: 'Expected output'
-      name: EXPECTED_OUTPUT
-      default: "Hello World!"
-      type: string
-  workspaces:
-  - name: cluster-credentials
-    optional: true
   tasks:
 ----
 
@@ -57,69 +46,32 @@ Example task declaration:
 ----
 tasks:
   - name: task-1
-    description: curl application endpoint, looking for certain text
+    description: Placeholder task that prints the Snapshot and outputs standard TEST_OUTPUT
     params:
       - name: SNAPSHOT
         value: $(params.SNAPSHOT)
-      - name: NAMESPACE
-        value: $(params.NAMESPACE)
-      - name: EXPECTED_OUTPUT
-        value: $(params.EXPECTED_OUTPUT)
-    workspaces:
-      - name: cluster-credentials
-        optional: true
     taskSpec:
       params:
       - name: SNAPSHOT
-      - name: NAMESPACE
-      - name: EXPECTED_OUTPUT
       results:
       - name: TEST_OUTPUT
         description: Test output
-      workspaces:
-      - name: cluster-credentials
-        workspace: cluster-credentials
       steps:
       - image: registry.redhat.io/openshift4/ose-cli:latest
         env:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
-        - name: NAMESPACE
-          value: $(params.NAMESPACE)
-        - name: EXPECTED_OUTPUT
-          value: $(params.EXPECTED_OUTPUT)
         script: |
           dnf -y install jq
 
-          # Get credentials to the namespace where the app is deployed
-          export KUBECONFIG=$(workspaces.cluster-credentials.path)/kubeconfig
+          echo -e "Example test task for the Snapshot:\n ${SNAPSHOT}"
+          // Run custom tests for the given Snapshot here
+          // After the tests finish, record the overall result in the RESULT variable
+          RESULT="SUCCESS"
 
-          # Use credentials to get the route for the application endpoint
-          COMPONENT_NAME=$(echo -n ${SNAPSHOT} | jq -r .components[0].name)
-          ROUTE_NAME=$(oc get routes -l app.kubernetes.io/name="${COMPONENT_NAME}" -o name)
-          HOST=$(oc get "${ROUTE_NAME}" -o jsonpath={.spec.host} -n "${NAMESPACE}")
-          echo "Found target host ${HOST} for app ${APPLICATION_NAME}"
-
-          # Wait up to 5 minutes for the endpoint output to match the expected output
-          for _ in $(seq 1 60); do
-            echo "Checking http://${HOST}"
-            # Check the application endpoint
-            ENDPOINT_OUTPUT=$(curl -s http://${HOST})
-
-            if [[ "${ENDPOINT_OUTPUT}" == "${EXPECTED_OUTPUT}" ]]; then
-              RESULT="SUCCESS"
-              break
-            else
-              RESULT="FAILURE"
-            fi
-            sleep 5
-          done
-
-          echo -e "The endpoint outputs the following:\n ${ENDPOINT_OUTPUT}"
-          echo -e "Expected endpoint output:\n ${EXPECTED_OUTPUT}"
-
+          // Output the standardized TEST_OUTPUT result in JSON form
           TEST_OUTPUT=$(jq -rc --arg date $(date +%s) --arg RESULT "${RESULT}" --null-input \
-            '{result: $RESULT, timestamp: $date, failures: 0, successes: 0, warnings: 0}')
+            '{result: $RESULT, timestamp: $date, failures: 0, successes: 1, warnings: 0}')
           echo -n "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
 
 ----
@@ -156,76 +108,36 @@ spec:
     optional: true
   tasks:
     - name: task-1
-      description: curl application endpoint, looking for certain text
+      description: Placeholder task that prints the Snapshot and outputs standard TEST_OUTPUT
       params:
         - name: SNAPSHOT
           value: $(params.SNAPSHOT)
-        - name: NAMESPACE
-          value: $(params.NAMESPACE)
-        - name: EXPECTED_OUTPUT
-          value: $(params.EXPECTED_OUTPUT)
-      workspaces:
-        - name: cluster-credentials
-          optional: true
       taskSpec:
         params:
         - name: SNAPSHOT
-        - name: NAMESPACE
-        - name: EXPECTED_OUTPUT
         results:
         - name: TEST_OUTPUT
           description: Test output
-        workspaces:
-        - name: cluster-credentials
-          workspace: cluster-credentials
         steps:
         - image: registry.redhat.io/openshift4/ose-cli:latest
           env:
           - name: SNAPSHOT
             value: $(params.SNAPSHOT)
-          - name: NAMESPACE
-            value: $(params.NAMESPACE)
-          - name: EXPECTED_OUTPUT
-            value: $(params.EXPECTED_OUTPUT)
           script: |
             dnf -y install jq
+            echo -e "Example test task for the Snapshot:\n ${SNAPSHOT}"
+            // Run custom tests for the given Snapshot here
+            // After the tests finish, record the overall result in the RESULT variable
+            RESULT="SUCCESS"
 
-            # Get credentials to the namespace where the app is deployed
-            export KUBECONFIG=$(workspaces.cluster-credentials.path)/kubeconfig
-
-            # Use credentials to get the route for the application endpoint
-            COMPONENT_NAME=$(echo -n ${SNAPSHOT} | jq -r .components[0].name)
-            ROUTE_NAME=$(oc get routes -l app.kubernetes.io/name="${COMPONENT_NAME}" -o name)
-            HOST=$(oc get "${ROUTE_NAME}" -o jsonpath={.spec.host} -n "${NAMESPACE}")
-            echo "Found target host ${HOST} for app ${APPLICATION_NAME}"
-
-            # Wait up to 5 minutes for the endpoint output to match the expected output
-            for _ in $(seq 1 60); do
-              echo "Checking http://${HOST}"
-              # Check the application endpoint
-              ENDPOINT_OUTPUT=$(curl -s http://${HOST})
-
-              if [[ "${ENDPOINT_OUTPUT}" == "${EXPECTED_OUTPUT}" ]]; then
-                RESULT="SUCCESS"
-                break
-              else
-                RESULT="FAILURE"
-              fi
-              sleep 5
-            done
-
-            echo -e "The endpoint outputs the following:\n ${ENDPOINT_OUTPUT}"
-            echo -e "Expected endpoint output:\n ${EXPECTED_OUTPUT}"
-
+            // Output the standardized TEST_OUTPUT result in JSON form
             TEST_OUTPUT=$(jq -rc --arg date $(date +%s) --arg RESULT "${RESULT}" --null-input \
-              '{result: $RESULT, timestamp: $date, failures: 0, successes: 0, warnings: 0}')
+              '{result: $RESULT, timestamp: $date, failures: 0, successes: 1, warnings: 0}')
             echo -n "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
 ----
 
 . Add your new custom test as an integration test in {ProductName}.
 .. For additional instructions on adding an integration test, see this document: xref:how-to-guides/testing_applications/proc_adding_an_integration_test.adoc[Adding an integration test].
-
-NOTE: This example test requires a temporary deployment. To use the example file, when adding it as an integration test in the {ProductName} UI, make sure to select the *development* option in the *Environment* field.  
 
 .Data injected into the PipelineRun of the integration test
 
@@ -234,11 +146,6 @@ When you create a custom integration test, {ProductName} automatically adds cert
 Parameters:
 
 * *`SNAPSHOT`*: contains the xref:../../glossary/index.adoc#_snapshot[snapshot] of the whole application as a JSON string. This JSON string provides useful information about the test, such as which components {ProductName} is testing, and what git repository and commit {ProductName} is using to build those components. For information about snapshot JSON string, see link:https://github.com/redhat-appstudio/integration-examples/blob/main/examples/snapshot_json_string_example[an example snapshot JSON string].
-* *`NAMESPACE`*:  indicates which namespace {ProductName} uses for temporary deployment, but only if your integration test specifies that {ProductName} should deploy the snapshot to an ephemeral environment during testing. This parameter can help you query Kubernetes resources that are deployed in the test environment, such as routes, deployments, and pods.
-
-Workspaces:
-
-* *`cluster-credentials`*: contains the connection credentials for the *Environment* containing the temporary deployment of your app, but only if your integration test specifies that {ProductName} should deploy the snapshot to an ephemeral environment during testing. These credentials enable you to query Kubernetes resources that are deployed in the test environment, such as routes, deployments, and pods.
 
 Labels:
 


### PR DESCRIPTION
* The ephemeral environments are deprecated and are being removed from Konflux
* Remove ephemeral environment references from the adding an integration test doc
* Remove ephemeral environment references and modify the example pipeline/task to stop using ephemeral environments from the creating a custom test doc