### PR TITLE
Update build-definitions references to new org

### DIFF
--- a/docs/modules/ROOT/pages/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/configuring-builds/proc_creating-secrets-for-your-builds.adoc
@@ -2,7 +2,7 @@
 
 When you building your pipelines, you might want to add tasks that require *secrets* in order to access external resources.
 
-NOTE: One such task is the link:https://github.com/redhat-appstudio/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `sast_snyk_task` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
+NOTE: One such task is the link:https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check[sast-snyk-check] task that that uses the third-party service link:https://snyk.io/[snyk] to perform static application security testing (SAST) as a part of the default {ProductName} pipeline. Use this procedure to upload your snyk.io token. Name the secret `sast_snyk_task` so that the snyk task in the {ProductName} pipeline will recognize it and use it.
 
 .Procedure 
 

--- a/docs/modules/ROOT/pages/how-to-guides/proc_hermetic-builds.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/proc_hermetic-builds.adoc
@@ -23,7 +23,7 @@ spec:
 ====
 * Hermetic builds disable network access, so a build with dependencies outside of its Git repository--including supported languages--might fail. To prevent this, or to pull in dependencies from a package manager for one of the xref:how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build.adoc#supported-languages[supported languages], follow the instructions in link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/how-to-guides/proc_prefetching-dependencies-to-support-hermetic-build/[Prefetching the package manager dependencies for the hermetic build].
 +
-Similarly, with a link:https://github.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.1/buildah.yaml[Buildah] task for a non-Java application, when you set the `*hermetic*` parameter to `true`, you’re isolating the build from the network, which restricts it to building only from dependencies listed in your Git repository. 
+Similarly, with a link:https://github.com/konflux-ci/build-definitions/blob/main/task/buildah/0.1/buildah.yaml[Buildah] task for a non-Java application, when you set the `*hermetic*` parameter to `true`, you’re isolating the build from the network, which restricts it to building only from dependencies listed in your Git repository. 
 
 * Do not add these parameters to the link:https://github.com/burrsutter/partner-catalog-stage/blob/e2ebb05ba8b4e842010710898d555ed3ba687329/.tekton/partner-catalog-stage-wgxd-pull-request.yaml#L87[`**pipelineSpec.params**`] section, as it should always display the default values for hermetic builds.
 ====

--- a/docs/modules/ROOT/pages/how-to-guides/proc_managing-compliance-with-the-enterprise-contract.adoc
+++ b/docs/modules/ROOT/pages/how-to-guides/proc_managing-compliance-with-the-enterprise-contract.adoc
@@ -19,7 +19,7 @@ If you ever need to restore the default EC integration test to an application, o
 . In the {ProductName} UI, open an existing application and go to the *Integration tests* tab.
 . Select *Add integration test*.
 . In the *Integration test name* field, enter a name of your choosing.
-. In the *GitHub URL* field, enter *https://github.com/redhat-appstudio/build-definitions*
+. In the *GitHub URL* field, enter *https://github.com/konflux-ci/build-definitions*
 . In the *Path in repository* field, to use the default EC configuration, enter */pipelines/enterprise-contract.yaml*
 .. You can also enter any of the paths in the link:https://github.com/enterprise-contract/config#readme[list of Enterprise Contract Configuration Files], to use a configuration that matches your specific needs more closely.
 .. For example, to verify your artifacts with the policy rules that Red Hat uses, enter */pipelines/enterprise-contract-redhat.yaml*
@@ -39,7 +39,7 @@ If you ever need to restore the default EC integration test to an application, o
 [role="_additional-resources"]
 .Additional resources
 * To produce a signed link:https://in-toto.io/in-toto/[in-toto] attestation of the build pipeline, go to link:https://tekton.dev/docs/chains/[Tekton Chains].
-* For information on the source code for the Tekton pipelines defined in the bundle, see the link:https://github.com/redhat-appstudio/build-definitions/blob/main/pipelines/enterprise-contract.yaml[build-definitions] and 
+* For information on the source code for the Tekton pipelines defined in the bundle, see the link:https://github.com/konflux-ci/build-definitions/blob/main/pipelines/enterprise-contract.yaml[build-definitions] and 
 link:https://github.com/enterprise-contract/ec-cli/blob/main/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml[ec-cli] repositories.
 * To use a specific version of the pipeline bundle instead of the devel tag, you can select one of the link:https://quay.io/repository/redhat-appstudio-tekton-catalog/pipeline-enterprise-contract?tab=tags[pinned tags].
 * For information on components in Enterprise Contract, see the link:https://enterprisecontract.dev/docs/ec/main/index.html#_components[Components].


### PR DESCRIPTION
STONEBLD-2339

The build-definitions repo has moved from github.com/redhat-appstudio to
github.com/konflux-ci. Update references accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
